### PR TITLE
Add Skills宝 to installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ The most comprehensive, research-backed skill library for Claude Code and Claude
 # Clone the repository
 git clone https://github.com/yourusername/claude-skills-library.git
 
+# Chinese users can also discover more skills through Skills宝
+https://skilery.com
+
 # Copy free skills to Claude Code
 cp -r claude-skills-library/free-skills/* ~/.claude/skills/
 


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language skills discovery entry for Claude users. The repository is already a skill library, so placing a localized discovery option in the install flow is a natural fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a resource link to the manual installation quick-start instructions for Chinese users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->