### PR TITLE
feat: world-class visual identity — hero SVG banner

### DIFF
--- a/.github/assets/hero.svg
+++ b/.github/assets/hero.svg
@@ -1,0 +1,137 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 300" width="1200" height="300">
+<defs>
+  <radialGradient id="bg" cx="50%" cy="50%" r="75%">
+    <stop offset="0%" stop-color="#07110e"/>
+    <stop offset="100%" stop-color="#0a0a0b"/>
+  </radialGradient>
+  <linearGradient id="titleGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#10b981"/>
+    <stop offset="100%" stop-color="#06b6d4"/>
+  </linearGradient>
+</defs>
+
+<!-- Background -->
+<rect width="1200" height="300" fill="url(#bg)"/>
+
+<!-- Skill card grid — left cluster (floating upward, staggered) -->
+<!-- Row 1 left -->
+<rect x="55" y="60" width="80" height="52" rx="6" fill="none" stroke="#10b981" stroke-width="1" opacity="0">
+  <animate attributeName="opacity" values="0;0.55;0.55;0" dur="5s" begin="0s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="60;48;48;60" dur="5s" begin="0s" repeatCount="indefinite"/>
+</rect>
+<rect x="63" y="69" width="30" height="4" rx="2" fill="#10b981" opacity="0">
+  <animate attributeName="opacity" values="0;0.5;0.5;0" dur="5s" begin="0s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="69;57;57;69" dur="5s" begin="0s" repeatCount="indefinite"/>
+</rect>
+<rect x="63" y="78" width="55" height="3" rx="1.5" fill="#06b6d4" opacity="0">
+  <animate attributeName="opacity" values="0;0.35;0.35;0" dur="5s" begin="0s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="78;66;66;78" dur="5s" begin="0s" repeatCount="indefinite"/>
+</rect>
+<rect x="63" y="85" width="40" height="3" rx="1.5" fill="#94a3b8" opacity="0">
+  <animate attributeName="opacity" values="0;0.25;0.25;0" dur="5s" begin="0s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="85;73;73;85" dur="5s" begin="0s" repeatCount="indefinite"/>
+</rect>
+
+<rect x="150" y="75" width="80" height="52" rx="6" fill="none" stroke="#06b6d4" stroke-width="1" opacity="0">
+  <animate attributeName="opacity" values="0;0.5;0.5;0" dur="5s" begin="0.6s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="75;63;63;75" dur="5s" begin="0.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="158" y="84" width="28" height="4" rx="2" fill="#06b6d4" opacity="0">
+  <animate attributeName="opacity" values="0;0.5;0.5;0" dur="5s" begin="0.6s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="84;72;72;84" dur="5s" begin="0.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="158" y="93" width="55" height="3" rx="1.5" fill="#10b981" opacity="0">
+  <animate attributeName="opacity" values="0;0.3;0.3;0" dur="5s" begin="0.6s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="93;81;81;93" dur="5s" begin="0.6s" repeatCount="indefinite"/>
+</rect>
+
+<rect x="245" y="55" width="80" height="52" rx="6" fill="none" stroke="#10b981" stroke-width="1" opacity="0">
+  <animate attributeName="opacity" values="0;0.6;0.6;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="55;43;43;55" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="253" y="64" width="35" height="4" rx="2" fill="#10b981" opacity="0">
+  <animate attributeName="opacity" values="0;0.55;0.55;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="64;52;52;64" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+</rect>
+
+<!-- Right cluster -->
+<rect x="875" y="65" width="80" height="52" rx="6" fill="none" stroke="#06b6d4" stroke-width="1" opacity="0">
+  <animate attributeName="opacity" values="0;0.5;0.5;0" dur="5s" begin="0.3s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="65;53;53;65" dur="5s" begin="0.3s" repeatCount="indefinite"/>
+</rect>
+<rect x="883" y="74" width="32" height="4" rx="2" fill="#06b6d4" opacity="0">
+  <animate attributeName="opacity" values="0;0.5;0.5;0" dur="5s" begin="0.3s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="74;62;62;74" dur="5s" begin="0.3s" repeatCount="indefinite"/>
+</rect>
+<rect x="883" y="83" width="55" height="3" rx="1.5" fill="#10b981" opacity="0">
+  <animate attributeName="opacity" values="0;0.3;0.3;0" dur="5s" begin="0.3s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="83;71;71;83" dur="5s" begin="0.3s" repeatCount="indefinite"/>
+</rect>
+
+<rect x="970" y="50" width="80" height="52" rx="6" fill="none" stroke="#10b981" stroke-width="1" opacity="0">
+  <animate attributeName="opacity" values="0;0.6;0.6;0" dur="5s" begin="0.9s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="50;38;38;50" dur="5s" begin="0.9s" repeatCount="indefinite"/>
+</rect>
+<rect x="978" y="59" width="40" height="4" rx="2" fill="#10b981" opacity="0">
+  <animate attributeName="opacity" values="0;0.55;0.55;0" dur="5s" begin="0.9s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="59;47;47;59" dur="5s" begin="0.9s" repeatCount="indefinite"/>
+</rect>
+<rect x="978" y="68" width="50" height="3" rx="1.5" fill="#06b6d4" opacity="0">
+  <animate attributeName="opacity" values="0;0.3;0.3;0" dur="5s" begin="0.9s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="68;56;56;68" dur="5s" begin="0.9s" repeatCount="indefinite"/>
+</rect>
+
+<rect x="1065" y="70" width="80" height="52" rx="6" fill="none" stroke="#06b6d4" stroke-width="1" opacity="0">
+  <animate attributeName="opacity" values="0;0.45;0.45;0" dur="5s" begin="1.5s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="70;58;58;70" dur="5s" begin="1.5s" repeatCount="indefinite"/>
+</rect>
+<rect x="1073" y="79" width="28" height="4" rx="2" fill="#06b6d4" opacity="0">
+  <animate attributeName="opacity" values="0;0.45;0.45;0" dur="5s" begin="1.5s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="79;67;67;79" dur="5s" begin="1.5s" repeatCount="indefinite"/>
+</rect>
+
+<!-- Small floating dots as pill/tag shapes -->
+<rect x="360" y="45" width="45" height="14" rx="7" fill="#10b981" opacity="0">
+  <animate attributeName="opacity" values="0;0.2;0.2;0" dur="4s" begin="0.4s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="45;35;35;45" dur="4s" begin="0.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="450" y="60" width="55" height="14" rx="7" fill="#06b6d4" opacity="0">
+  <animate attributeName="opacity" values="0;0.18;0.18;0" dur="4.5s" begin="1.1s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="60;48;48;60" dur="4.5s" begin="1.1s" repeatCount="indefinite"/>
+</rect>
+<rect x="700" y="50" width="50" height="14" rx="7" fill="#10b981" opacity="0">
+  <animate attributeName="opacity" values="0;0.2;0.2;0" dur="4s" begin="0.7s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="50;40;40;50" dur="4s" begin="0.7s" repeatCount="indefinite"/>
+</rect>
+<rect x="790" y="42" width="40" height="14" rx="7" fill="#06b6d4" opacity="0">
+  <animate attributeName="opacity" values="0;0.18;0.18;0" dur="3.8s" begin="1.8s" repeatCount="indefinite"/>
+  <animate attributeName="y" values="42;32;32;42" dur="3.8s" begin="1.8s" repeatCount="indefinite"/>
+</rect>
+
+<!-- Horizontal divider line -->
+<line x1="80" y1="228" x2="1120" y2="228" stroke="#10b981" stroke-width="0.5" opacity="0.12"/>
+
+<!-- Title -->
+<text x="600" y="168"
+  font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace"
+  font-size="28" font-weight="700" text-anchor="middle" letter-spacing="3"
+  fill="url(#titleGrad)">CLAUDE SKILLS LIBRARY</text>
+
+<!-- Tagline -->
+<text x="600" y="200"
+  font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace"
+  font-size="14" text-anchor="middle" fill="#94a3b8" letter-spacing="0.5"
+  >Portable AI capabilities for every coding environment</text>
+
+<!-- Skill count badge -->
+<rect x="524" y="214" width="152" height="22" rx="11" fill="#10b981" opacity="0.12"/>
+<text x="600" y="229"
+  font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace"
+  font-size="11" text-anchor="middle" fill="#10b981" opacity="0.8" letter-spacing="1"
+  >107 skills · MIT · 6 runtimes</text>
+
+<!-- Built on SIP -->
+<text x="24" y="283"
+  font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace"
+  font-size="11" fill="#f59e0b" opacity="0.8">Built on SIP</text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<p align="center"><img src=".github/assets/hero.svg" width="100%" alt="Claude Skills Library hero banner"/></p>
+
 <div align="center">
 
 # 🧠 Claude Skills Library

--- a/docs/readme-template.md
+++ b/docs/readme-template.md
@@ -49,10 +49,14 @@ graph TD
 
 ## Links
 
+Copy these into your README — replace destinations with your actual paths:
+
+```markdown
 - [Documentation](docs/)
 - [Contributing](CONTRIBUTING.md)
 - [Changelog](CHANGELOG.md)
 - [Issues](../../issues)
+```
 
 ---
 

--- a/docs/readme-template.md
+++ b/docs/readme-template.md
@@ -1,0 +1,114 @@
+<p align="center">
+  <img src=".github/assets/hero.svg" width="100%" alt="[Repo Name] — [tagline]"/>
+</p>
+
+# [REPO NAME]
+
+> [One-line value proposition — what it does and why it matters. 15 words max.]
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-emerald.svg)](LICENSE)
+[![Status: Active](https://img.shields.io/badge/Status-Active-10b981.svg)]()
+[![Built on SIP](https://img.shields.io/badge/Built_on-SIP-06b6d4.svg)](https://github.com/frankxai/Starlight-Intelligence-System)
+
+---
+
+## What it is
+
+[3 sentences max. No hype. Concrete nouns only: what it does, what it produces, who uses it.]
+
+---
+
+## Quickstart
+
+```bash
+# Minimal working example — copy-paste and run
+```
+
+---
+
+## Architecture
+
+```mermaid
+graph TD
+    A[Input] --> B[Core Module]
+    B --> C[Output]
+    B --> D[Side Effects]
+```
+
+---
+
+## Key features
+
+| Feature | Description |
+|---------|-------------|
+| **Feature 1** | What it does concretely |
+| **Feature 2** | What it does concretely |
+| **Feature 3** | What it does concretely |
+
+---
+
+## Links
+
+- [Documentation](docs/)
+- [Contributing](CONTRIBUTING.md)
+- [Changelog](CHANGELOG.md)
+- [Issues](../../issues)
+
+---
+
+<p align="center">
+  <sub>Part of the <a href="https://github.com/frankxai/Starlight-Intelligence-System">Starlight Intelligence</a> ecosystem · Built on SIP</sub>
+</p>
+
+---
+
+## README standard — usage guide
+
+This template defines the visual identity standard for all 16 Starlight/FrankX repos.
+
+### Required elements
+
+1. **Hero SVG banner** at `.github/assets/hero.svg`
+   - 1200×300px, `viewBox="0 0 1200 300"`
+   - Background: `#0a0a0b` (void black)
+   - Brand palette: emerald `#10b981`, cyan `#06b6d4`, amber `#f59e0b`, gold `#fbbf24`
+   - SMIL `<animate>` / `<animateTransform>` for GitHub-native rendering
+   - Under 30KB
+   - "Built on SIP" footer in amber
+   - Visually unique to the repo's purpose
+
+2. **Badge row** — shields.io, consistent across all repos
+   - License (MIT or CC-BY-4.0)
+   - Status (Active / In Progress / Draft)
+   - "Built on SIP" link to Starlight-Intelligence-System
+
+3. **H1 + one-line value prop** — 15 words max, no marketing language
+
+4. **"What it is" section** — 3 sentences, concrete nouns
+
+5. **Quickstart** — copy-paste runnable example
+
+6. **Architecture diagram** — Mermaid, renders natively on GitHub
+
+7. **Key features table** — 3–6 rows, concrete descriptions
+
+8. **Ecosystem footer** — links back to Starlight-Intelligence-System
+
+### Voice rules
+
+- No spiritual/transformation language
+- Lead with what it does, not philosophy
+- Concrete nouns over abstract claims
+- Link to evidence, not assertions
+
+### SVG visual themes by repo type
+
+| Repo type | Suggested visual theme |
+|-----------|----------------------|
+| Agent/AI system | Network graph with pulsing nodes |
+| Ocean/nature | Marine constellation, wave patterns |
+| Music/audio | Equalizer bars, musical staff |
+| OS/platform | Dashboard panels, terminal cursor |
+| Library/skills | Floating cards, skill network |
+| Data/evals | Bar charts, score displays |
+| Swarm | Honeycomb, distributed nodes |


### PR DESCRIPTION
## Summary

- Adds `.github/assets/hero.svg` — animated 1200×300px hero banner with skill-cards-in-a-library theme: rows of abstract card shapes (with title/body lines) floating upward in staggered sequence, pill/tag shapes drifting up in the gaps, skill count badge below the tagline
- Prepends `<img>` tag to `README.md` above the existing `<div align="center">` block so the banner renders first on the GitHub repo page
- Colors: emerald primary (`#10b981`), cyan accents (`#06b6d4`)
- Footer: "Built on SIP" in amber
- Under 30KB, SMIL animations render in GitHub `<img>` tags

## Test plan

- [ ] Preview `.github/assets/hero.svg` in a browser to verify staggered card float animations
- [ ] Check README renders correctly on the GitHub repo page
- [ ] Confirm banner displays at full width on both desktop and mobile GitHub views

---
_Generated by [Claude Code](https://claude.ai/code/session_01X52gLB2yReWBwhehCpdoMu)_