### PR TITLE
docs: curated-lanes banner (skills + creator-skills flagships)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@
 
 ---
 
+> [!TIP]
+> **New — curated lanes.** The best of this library, curated and actively maintained as two installable flagships:
+> [`frankxai/skills`](https://github.com/frankxai/skills) for AI architects (MCP, orchestration, model routing, context engineering) and
+> [`frankxai/creator-skills`](https://github.com/frankxai/creator-skills) for creators (video routing, music, images, brand voice).
+> Install with `npx skills add frankxai/skills` or `npx skills add frankxai/creator-skills`.
+> This library remains the full catalog.
+
 ## ⚡ Quick start
 
 **Option A — install as a Claude Code plugin (recommended).** One command, auto-updating:


### PR DESCRIPTION
Adds a tip banner at the top of the README pointing to the two new curated flagship repos:

- frankxai/skills — architect lane
- frankxai/creator-skills — creator lane

Positioning: flagships are the curated entry points; this library remains the full 107-skill catalog. README-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a highlighted tip in the README promoting curated installable collections.
  * Included ready-to-run install commands for two flagship skill sets.
  * Clarified that the main library still contains the full catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->