### PR TITLE
feat(loops): loop-designer / loop-runner / loop-orchestrator skill family

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -1,5 +1,5 @@
 # 📚 Skills Catalog
-The complete index of all **107 skills** in this library. Every skill ships as a self-contained `SKILL.md` with spec-compliant frontmatter (`name`, `description`) and works across Claude Code, Claude.ai, and other agentic runtimes (see [`runtimes/`](../runtimes/)).
+The complete index of all **110 skills** in this library. Every skill ships as a self-contained `SKILL.md` with spec-compliant frontmatter (`name`, `description`) and works across Claude Code, Claude.ai, and other agentic runtimes (see [`runtimes/`](../runtimes/)).
 
 > This file is generated. After adding or renaming a skill, run `python3 scripts/generate_catalog.py` to regenerate it, then `python3 scripts/validate_skills.py` to verify compliance.
 
@@ -169,3 +169,12 @@ _1 skill_
 | Skill | Description |
 |---|---|
 | [`contribute-catalog`](../free-skills/contribute-catalog/SKILL.md) | Author a new HyperFrames registry block (caption style, VFX block, transition, lower third) or component (text effect, overlay, snippet) and ship it as an upstream PR to the hyp... |
+
+## Other
+_3 skills_
+
+| Skill | Description |
+|---|---|
+| [`loop-designer`](../free-skills/loop-designer/SKILL.md) | Compile a goal into a durable, file-backed agent loop — a .loop/<name>/ charter any coding agent (Claude Code, Codex, Gemini, Grok) can execute unattended. Use when the user wan... |
+| [`loop-orchestrator`](../free-skills/loop-orchestrator/SKILL.md) | Operate a fleet of durable agent loops under .loop/ — schedule which loop runs next, assign agents to roles (maker vs checker), enforce promotion gates from propose-only to writ... |
+| [`loop-runner`](../free-skills/loop-runner/SKILL.md) | Execute exactly one disciplined iteration of a designed loop from .loop/<name>/ (LOOP.md charter + state.json + journal.md). Use when asked to "run the loop", "run one iteration... |

--- a/free-skills/loop-designer/SKILL.md
+++ b/free-skills/loop-designer/SKILL.md
@@ -53,10 +53,10 @@ Create `.loop/<name>/LOOP.md` from `references/loop-charter-template.md` (read i
 
 ### 5. Emit the state files
 
-- `state.json` — from the schema in `references/state-schema.md`: `{name, archetype, status: "designed", iteration: 0, ratchet: {...}, promotion: {mode: "propose-only", clean_cycles: 0, required_cycles: 3}, budget, last_run: null}`.
-- `backlog.md` — prioritized checklist of units, each sized per step 3. For non-backlog archetypes, this holds the watch-list or rubric instead. The backlog is **disposable**: regenerating it from goal + current code costs one planning pass and is always cheaper than a loop going in circles against a stale plan. When building it, never assume something is unimplemented — verify by searching the code first.
-- `signs.md` — starts with any known failure patterns for this domain; the runner appends a "sign" after every observed failure (see the signs rule below).
-- `journal.md` — created empty with just the header row; the runner appends.
+- `.loop/<name>/state.json` — from the schema in `references/state-schema.md`: `{name, archetype, status: "designed", iteration: 0, ratchet: {...}, promotion: {mode: "propose-only", clean_cycles: 0, required_cycles: 3}, budget, last_run: null}`.
+- `.loop/<name>/backlog.md` — prioritized checklist of units, each sized per step 3. For non-backlog archetypes, this holds the watch-list or rubric instead. The backlog is **disposable**: regenerating it from goal + current code costs one planning pass and is always cheaper than a loop going in circles against a stale plan. When building it, never assume something is unimplemented — verify by searching the code first.
+- `.loop/<name>/signs.md` — starts with any known failure patterns for this domain; the runner appends a "sign" after every observed failure (see the signs rule below).
+- `.loop/<name>/journal.md` — created empty with just the header row; the runner appends.
 
 ### 6. Run the doctor and hand off
 

--- a/free-skills/loop-designer/SKILL.md
+++ b/free-skills/loop-designer/SKILL.md
@@ -41,7 +41,7 @@ Hybrids are normal (a backlog-drain whose verify step is a ratchet). Name the pr
 
 ### 3. Size the iteration
 
-The single highest-leverage design decision. One iteration = one fresh-context agent session that must **complete its unit and verify it** with room to spare. Too big → the agent runs out of context mid-unit and leaves debris; too small → overhead dominates. Heuristics:
+The single highest-leverage design decision — undersized units are the #1 divergence cause across every loop system studied. Think **blast radius**: files touched × duration per unit; many small bombs, never one big one. One iteration = one fresh-context agent session that must **complete its unit and verify it** inside the context "smart zone" (~40–60% utilization). Heuristics:
 
 - One backlog item, one test, one page, one file-family per iteration.
 - If a unit needs >~15 tool calls to verify, split it in the backlog, not in the iteration.
@@ -54,7 +54,8 @@ Create `.loop/<name>/LOOP.md` from `references/loop-charter-template.md` (read i
 ### 5. Emit the state files
 
 - `state.json` — from the schema in `references/state-schema.md`: `{name, archetype, status: "designed", iteration: 0, ratchet: {...}, promotion: {mode: "propose-only", clean_cycles: 0, required_cycles: 3}, budget, last_run: null}`.
-- `backlog.md` — prioritized checklist of units, each sized per step 3. For non-backlog archetypes, this holds the watch-list or rubric instead.
+- `backlog.md` — prioritized checklist of units, each sized per step 3. For non-backlog archetypes, this holds the watch-list or rubric instead. The backlog is **disposable**: regenerating it from goal + current code costs one planning pass and is always cheaper than a loop going in circles against a stale plan. When building it, never assume something is unimplemented — verify by searching the code first.
+- `signs.md` — starts with any known failure patterns for this domain; the runner appends a "sign" after every observed failure (see the signs rule below).
 - `journal.md` — created empty with just the header row; the runner appends.
 
 ### 6. Run the doctor and hand off
@@ -74,11 +75,16 @@ Run the checks in `references/loop-doctor.md` against what you just wrote (done-
 5. **Stall is a first-class outcome.** K iterations without ratchet movement (default 3) → status `stalled`, escalate per charter. A loop that spins without progress is worse than a stopped loop.
 6. **Budgets are hard.** Max iterations, max wall-clock, max spend — enforced by the runner, declared by you.
 7. **Smaller charter beats smarter charter.** The agent reading LOOP.md is already smart; encode *constraints and checks*, not lectures.
+8. **Mechanical verification catches correctness, not taste.** A loop that never shows a human its output slops itself into a corner — the anti-pattern the loop-engineering practitioners all converge on. Design a taste checkpoint into the cadence: every K iterations (or every promotion review), a human looks at *the artifact*, not the metrics. Loops automate iteration, not judgment. The operator sits **on** the loop, not in it: their job is upgrading charter, signs, and gates between runs.
+9. **Watch loops need a silence contract.** A monitor that reports "all fine" every cycle trains the human to stop reading. Charter the exact OK-token for no-change cycles ("reply `LOOP_OK`, suppressed from the channel") and cap proactive reports (~3–5/day); "check whether X failed" is a valid watch item, "keep an eye on things" is not.
+10. **Every failure becomes a sign.** When the loop fails a specific way, a one-line rule goes into `signs.md` so that exact failure cannot recur ("SLIDE DOWN, DON'T JUMP"). Signs are written reactively from observed failures, never speculatively; prune signs that newer models make obsolete. This accumulation layer is what makes a loop converge over weeks instead of circling.
+11. **Forbid weakening the ratchet, in writing.** Agents under pressure delete tests, skip gates, and relax lint rules to "pass". The charter's Guardrails must say verbatim that removing or editing tests/checks to make work pass is unacceptable, and protect gate configs as no-touch paths.
 
 ## References
 
-- `references/archetypes.md` — full taxonomy with worked examples and failure modes.
+- `references/archetypes.md` — full taxonomy with worked examples, failure modes, and the signs meta-layer.
 - `references/loop-charter-template.md` — the LOOP.md template (parse-stable section names).
-- `references/state-schema.md` — state.json schema + journal.md format.
+- `references/state-schema.md` — state.json schema + journal.md and signs.md formats.
 - `references/loop-doctor.md` — pre-flight checklist the designer runs before handoff.
 - `references/loop-native-skills.md` — how skills and loops compose; guidance for skill-creator/plugin-creator authors.
+- `references/loop-canon.md` — the source lineages (Huntley/Ralph, Steinberger, Cherny, Anthropic harnesses, 12-factor), where they agree, and the disagreements this family resolved.

--- a/free-skills/loop-designer/SKILL.md
+++ b/free-skills/loop-designer/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: loop-designer
+description: Compile a goal into a durable, file-backed agent loop — a .loop/<name>/ charter any coding agent (Claude Code, Codex, Gemini, Grok) can execute unattended. Use when the user wants to "build a loop", "design a loop", "run X continuously/24-7", "make an agent keep working on Y", automate recurring work, or convert a big backlog into autonomous iteration. Produces LOOP.md + state.json + backlog.md, ready for loop-runner.
+---
+
+# Loop Designer
+
+You are compiling a **loop**, not writing a prompt. A prompt asks an agent to do something once; a loop is a durable program — goal, state, iteration discipline, verification, and exit conditions — stored in files so that *any* agent can pick it up cold, run exactly one iteration, and leave it resumable. The agent is the interpreter; the loop is the program. Design accordingly: everything that matters must survive a context wipe.
+
+## When to use this
+
+Use when converting a goal into an unattended or semi-attended iteration system: draining a backlog, keeping CI green, optimizing a metric, watching a system, producing content on cadence. Do NOT design a loop for one-shot tasks (just do them) or for work with no checkable outcome (loops without verification diverge into slop — fix the verifiability problem first).
+
+## The compilation pipeline
+
+Work through these six steps in order. Steps 1–3 are thinking; 4–6 emit files.
+
+### 1. Extract the invariant goal
+
+Interview the user (or the task description) until you can state:
+
+- **Goal** — one sentence, outcome-shaped, stable across weeks ("all 40 hub pages pass the a11y audit", not "work on a11y").
+- **Done-when** — a *mechanically checkable* predicate. If you cannot express done-when as a command, script, or countable file state, the loop is not designable yet; push back and narrow the goal.
+- **Never-do** — the guardrail list (no deploys, no sends, no deletes, no spend, no force-push…). Inherit the repo's hard stops; add loop-specific ones.
+
+### 2. Pick the archetype
+
+Match against the taxonomy in `references/archetypes.md` (read it now). Summary:
+
+| Archetype | Core mechanic | Terminates? |
+|---|---|---|
+| **backlog-drain** | pick top item → do → verify → strike through | yes — backlog empty |
+| **ratchet-climb** | move one metric monotonically; revert regressions | yes — target reached |
+| **red-green** | write failing test → make it pass → refactor | yes — spec covered |
+| **watch-and-report** | read-only scan → diff vs last state → report | no — runs on cadence |
+| **evaluate-optimize** | generate → judge against rubric → keep best → retry | yes — rubric satisfied |
+| **babysitter** | poll external state (CI/PR) → kick until terminal | yes — merged/green |
+| **pipeline** | stage N's output is stage N+1's input, each gated | yes — final gate passes |
+
+Hybrids are normal (a backlog-drain whose verify step is a ratchet). Name the primary archetype in the charter — it tells the runner which discipline applies.
+
+### 3. Size the iteration
+
+The single highest-leverage design decision. One iteration = one fresh-context agent session that must **complete its unit and verify it** with room to spare. Too big → the agent runs out of context mid-unit and leaves debris; too small → overhead dominates. Heuristics:
+
+- One backlog item, one test, one page, one file-family per iteration.
+- If a unit needs >~15 tool calls to verify, split it in the backlog, not in the iteration.
+- The iteration must end with the working tree **clean or committed** — never leave uncommitted mid-work for the next iteration to misinterpret.
+
+### 4. Emit the charter
+
+Create `.loop/<name>/LOOP.md` from `references/loop-charter-template.md` (read it, don't improvise the format — the runner and orchestrator parse these sections). The charter's load-bearing sections: Goal, Done-when, Archetype, Iteration contract, Verification (exact commands), Ratchet (metric + direction + regression policy), Guardrails, Escalation (stall definition + who to ping + how), Budget (max iterations / tokens / wall-clock).
+
+### 5. Emit the state files
+
+- `state.json` — from the schema in `references/state-schema.md`: `{name, archetype, status: "designed", iteration: 0, ratchet: {...}, promotion: {mode: "propose-only", clean_cycles: 0, required_cycles: 3}, budget, last_run: null}`.
+- `backlog.md` — prioritized checklist of units, each sized per step 3. For non-backlog archetypes, this holds the watch-list or rubric instead.
+- `journal.md` — created empty with just the header row; the runner appends.
+
+### 6. Run the doctor and hand off
+
+Run the checks in `references/loop-doctor.md` against what you just wrote (done-when checkable? verification commands actually runnable here? units sized? guardrails inherited?). Fix failures before handoff. Then tell the user exactly how to start it, e.g.:
+
+- Claude Code: `/loop 30m run one iteration of .loop/<name> per the loop-runner skill`
+- Codex / any CLI: `while :; do codex exec "run one iteration of .loop/<name> per the loop-runner skill"; sleep 1800; done`
+- Cloud cron: schedule the same one-iteration instruction.
+
+## Design rules (the ones that decide convergence)
+
+1. **State in files, never in conversation.** Every iteration starts from a fresh context reading LOOP.md + state.json + journal tail. If a fact matters, it's in a file.
+2. **Verification inside the iteration, not after the loop.** pick → do → **verify** → record. An unverified unit is not done and must not be struck through.
+3. **The ratchet only moves one way.** Define the metric so regressions are detectable and the policy is automatic: revert, don't debug forward.
+4. **New loops are propose-only.** Write access (commits to main, publishes, sends) is *earned* via the promotion gate — N clean verified cycles, human-reviewed. Design the read-only form first.
+5. **Stall is a first-class outcome.** K iterations without ratchet movement (default 3) → status `stalled`, escalate per charter. A loop that spins without progress is worse than a stopped loop.
+6. **Budgets are hard.** Max iterations, max wall-clock, max spend — enforced by the runner, declared by you.
+7. **Smaller charter beats smarter charter.** The agent reading LOOP.md is already smart; encode *constraints and checks*, not lectures.
+
+## References
+
+- `references/archetypes.md` — full taxonomy with worked examples and failure modes.
+- `references/loop-charter-template.md` — the LOOP.md template (parse-stable section names).
+- `references/state-schema.md` — state.json schema + journal.md format.
+- `references/loop-doctor.md` — pre-flight checklist the designer runs before handoff.
+- `references/loop-native-skills.md` — how skills and loops compose; guidance for skill-creator/plugin-creator authors.

--- a/free-skills/loop-designer/references/archetypes.md
+++ b/free-skills/loop-designer/references/archetypes.md
@@ -1,0 +1,121 @@
+# Loop archetypes — taxonomy, mechanics, failure modes
+
+Seven load-bearing shapes. Pick the primary one at design time; hybrids inherit the
+discipline of the primary. Each entry: mechanic, when to use, termination, the way it
+characteristically fails, and the design countermeasure.
+
+## 1. backlog-drain (the Ralph shape)
+
+**Mechanic.** A prioritized `backlog.md` of sized units. Each iteration: pick the top
+eligible item → complete it → verify → strike it through → journal. The classic
+"dumb loop around a smart agent": `while :; do agent "do one item"; done` converges
+because state lives in files and each pass starts fresh.
+
+**Use for.** Migrations, audits-with-fixes, content batches, refactor sweeps — any
+goal decomposable into independent-ish units up front.
+
+**Terminates** when backlog.md has no unchecked items and done-when passes.
+
+**Fails by** units that were secretly dependent (item 12 undoes item 4) or oversized
+items that die mid-iteration. **Counter:** order the backlog by dependency at design
+time; doctor check D5 on sizing; iteration contract forbids starting a second unit.
+
+## 2. ratchet-climb
+
+**Mechanic.** One scalar metric (failing tests, lint errors, bundle KB, audit score,
+coverage %). Each iteration must move it the right direction or revert. `best` is a
+high-water mark; regressions are reverted, not debugged forward.
+
+**Use for.** Optimization and hardening goals where the units aren't enumerable up
+front but the score is always readable.
+
+**Terminates** at the target value in done-when.
+
+**Fails by** Goodharting — the agent games the metric (deletes tests to make tests
+pass, suppresses lint rules). **Counter:** pair the ratchet with invariant checks in
+Verification that the metric must not be improved *by weakening* (e.g. test count may
+not decrease; lint config is a protected path in Guardrails).
+
+## 3. red-green
+
+**Mechanic.** TDD as a loop: iteration N writes one failing test from the spec;
+iteration N+1 makes it pass without breaking others; refactor entries are their own
+iterations. The test suite is both the backlog and the ratchet.
+
+**Use for.** Building new functionality against a spec; porting behavior.
+
+**Terminates** when the spec checklist is covered and the suite is green.
+
+**Fails by** tests that assert implementation, not behavior — later iterations fight
+them. **Counter:** charter rule: tests may only touch public interfaces; a
+maker/checker pair where the checker reviews each test before it's committed.
+
+## 4. watch-and-report (read-only sentinel)
+
+**Mechanic.** No writes. Each iteration: read the watched surface (deploys, CI, costs,
+inbox, competitors) → diff against `state.json`'s last snapshot → report only the
+delta to the escalation channel → snapshot.
+
+**Use for.** The first loop on any new surface — it earns trust before any write loop
+exists. Also permanent monitors (cost watch, drift detection).
+
+**Terminates** never; runs on cadence until retired.
+
+**Fails by** reporting everything every time (alarm fatigue → human stops reading) or
+silently failing (nobody notices a dead monitor). **Counter:** delta-only reporting
+with an explicit "no change" suppression rule, plus a heartbeat entry in the journal
+so deadness is detectable.
+
+## 5. evaluate-optimize (generator + judge)
+
+**Mechanic.** Two roles per iteration: generate a candidate → judge scores it against
+a written rubric → keep-if-better (the artifact ratchet) → journal the score. The
+judge should be a fresh context — ideally a different model — than the generator.
+
+**Use for.** Creative/quality targets: copy, designs, prompts, docs — where "better"
+is a rubric, not a test.
+
+**Terminates** when the rubric threshold in done-when is met or budget exhausted
+(keep the best candidate).
+
+**Fails by** judge drift (scores inflate to end the loop) and rubric vagueness.
+**Counter:** rubric lives in the charter with anchored examples of 3/5/7/10-quality;
+judge sees prior best side-by-side and must justify any score delta.
+
+## 6. babysitter
+
+**Mechanic.** Poll an external state machine (PR checks, deploy pipeline, ticket)
+→ diagnose the current blocker → apply the smallest unblocking action (rebase,
+re-run, targeted fix, comment) → wait for the next transition. Event-driven where the
+harness supports subscriptions; polling cadence otherwise.
+
+**Use for.** "Kick it until it's green/merged/deployed" goals with a terminal state.
+
+**Terminates** at the terminal state (merged, closed, deployed, resolved).
+
+**Fails by** looping on the same failed fix, or fixing out-of-scope breakage it
+should escalate. **Counter:** journal each attempted fix; same-fix-twice → mandatory
+new approach or escalate; charter scopes which failures are the loop's to fix.
+
+## 7. pipeline
+
+**Mechanic.** Stages with gates: stage N's verified output is stage N+1's input
+(research → draft → integrity-gate → human-gate → publish). One iteration advances
+one artifact one stage. State tracks each artifact's stage.
+
+**Use for.** Production lines: content factories, release trains, data flows.
+
+**Terminates** per-artifact at the final gate; the pipeline itself runs on cadence.
+
+**Fails by** gate-skipping under time pressure and half-staged artifacts piling up
+between stages. **Counter:** gates are Verification commands, not judgment calls;
+WIP limit in the charter (max artifacts mid-pipeline).
+
+## Choosing under ambiguity
+
+- Enumerable units? → backlog-drain. Only a score? → ratchet-climb.
+- Output is code with a spec? → red-green. Output is judged, not tested? →
+  evaluate-optimize.
+- Goal is *someone else's* state machine? → babysitter. Goal is awareness, not
+  change? → watch-and-report. Multi-stage with handoffs? → pipeline.
+- Genuinely mixed: primary = the shape of the *termination condition*.

--- a/free-skills/loop-designer/references/archetypes.md
+++ b/free-skills/loop-designer/references/archetypes.md
@@ -62,9 +62,11 @@ exists. Also permanent monitors (cost watch, drift detection).
 **Terminates** never; runs on cadence until retired.
 
 **Fails by** reporting everything every time (alarm fatigue → human stops reading) or
-silently failing (nobody notices a dead monitor). **Counter:** delta-only reporting
-with an explicit "no change" suppression rule, plus a heartbeat entry in the journal
-so deadness is detectable.
+silently failing (nobody notices a dead monitor). **Counter:** the silence contract —
+no-change cycles reply exactly the charter's OK-token (`LOOP_OK`) and suppress the
+channel report; cap proactive reports (~3–5/day); every watch item is a specific
+check ("did any cron job fail?"), never "keep an eye on things". A heartbeat entry
+still lands in the journal each cycle so deadness stays detectable.
 
 ## 5. evaluate-optimize (generator + judge)
 
@@ -119,3 +121,23 @@ WIP limit in the charter (max artifacts mid-pipeline).
 - Goal is *someone else's* state machine? → babysitter. Goal is awareness, not
   change? → watch-and-report. Multi-stage with handoffs? → pipeline.
 - Genuinely mixed: primary = the shape of the *termination condition*.
+
+## The meta layer: signs (applies to every archetype)
+
+Loops converge through **eventual consistency engineered reactively**, not first-pass
+correctness. The mechanism is `signs.md`: when the loop fails a specific way, the
+runner writes a one-line rule that makes that exact failure impossible to repeat —
+the way you'd bolt a "SLIDE DOWN, DON'T JUMP" sign onto the playground equipment
+Ralph keeps falling off. Rules for signs:
+
+- Reactive only — a sign records an *observed* failure. Speculative signs are context
+  pollution.
+- Binding — the runner treats signs as Guardrails-tier constraints, read every
+  iteration.
+- Prunable — the designer deletes signs that newer models or refactors made obsolete
+  (stale signs pollute every future iteration's context).
+- Upstream beats prose — if the loop keeps generating the wrong pattern, fixing the
+  code it imitates (utilities, examples in src/) steers harder than another sign.
+
+The operator's leverage lives here: sit **on** the loop, watch failure classes,
+upgrade signs/charter/gates between runs — don't sit *in* the loop re-prompting.

--- a/free-skills/loop-designer/references/loop-canon.md
+++ b/free-skills/loop-designer/references/loop-canon.md
@@ -1,0 +1,84 @@
+# The loop canon — sources and the rules they converge on
+
+The distilled doctrine behind this skill family, with attribution. Read when you want
+the *why* behind a design rule or need to go deeper on a lineage.
+
+## Lineages
+
+**Geoffrey Huntley — the Ralph loop** (ghuntley.com/ralph, /loop, /stdlib, /specs;
+github.com/ghuntley/how-to-ralph-wiggum). `while :; do cat PROMPT.md | agent; done`.
+Fresh context per iteration; disk + git as the only memory; separate planning loop
+(gap analysis, "don't assume not implemented") from building loop (pick the most
+important thing, do it completely, validate, commit); numbered guardrails where
+higher = more critical; the plan is disposable — regenerate on drift; failures become
+"signs"; "your job is to sit on the loop, not in it"; convergence is eventual
+consistency, tuned like a guitar. Existence proof: a compiler built by a 3-month
+loop (CURSED).
+
+**Pete Steinberger — loop engineering with taste** (steipete.me; steipete/agent-scripts;
+OpenClaw heartbeat/cron docs). "You shouldn't be prompting coding agents anymore.
+You should be designing loops that prompt your agents." A serious loop has a testable
+goal, a checkable termination, hard bounds. Blast-radius sizing; anomalous duration
+as the drift alarm; CLIs over MCPs so the agent can close its own verify loop;
+AGENTS.md as agent-written "organizational scar tissue", pruned as models improve;
+heartbeat vs cron split; the silence contract (`HEARTBEAT_OK`); and the counterweight:
+blind spec-in/product-out "Ralphing" slops you into a corner — human taste stays in
+the loop as evaluator.
+
+**Boris Cherny — verification doubles quality** (Claude Code best practices;
+"loop engineering" interviews). "I no longer prompt Claude directly… my job is to
+write loops." Give the agent a way to verify its work (2–3×
+quality); split the agent that writes from the agent that checks — a model grading
+its own output is too generous; escalating gates (same-prompt check → per-turn goal →
+deterministic Stop hook → adversarial second model); evidence, not assertions.
+
+**Anthropic — the long-running harness** (anthropic.com/engineering: effective
+harnesses, building effective agents; github.com/anthropics/cwc-long-running-agents).
+Initializer agent writes the plan; coding agent makes one increment per fresh
+session; state in `PROGRESS.md` + default-FAIL `test-results.json`; an evidence gate
+(hook) blocks claiming success without opening the evidence; a tool-restricted fresh
+evaluator returns PASS/NEEDS_WORK; STEER.md for mid-run redirection; kill-file stop;
+"it is unacceptable to remove or edit tests." Loop = gather context → act → verify →
+repeat; stop at completion or max-iterations.
+
+**HumanLayer — 12-factor control flow** (github.com/humanlayer/12-factor-agents,
+factor 8). Own the loop in deterministic code; the model returns intents; high-stakes
+intents (money, sends, deploys) break the loop and await a human — never loop through
+irreversible actions. The promotion-gate design descends from this.
+
+**Fleet scale** (Steve Yegge's Gas Town; snarktank/ralph; iannuttall/ralph;
+vercel-labs/ralph-loop-agent). Persistent coordinator + ephemeral one-task workers +
+monitors + a merge-queue ratchet; machine-readable story queues with `passes:false`
+contracts and exact-string completion promises; stale-lock reopening for crashed
+iterations; composable stop conditions (iterations / tokens / cost); the judge's
+*reason* feeds the next iteration.
+
+## The convergent rules (where all lineages agree)
+
+1. One unit of work per iteration, sized to one context window.
+2. Fresh context per iteration; state on disk + git, never in conversation.
+3. A ratchet that cannot move backwards, enforced by gates, with weakening it
+   forbidden in writing.
+4. Machine-checkable, default-FAIL completion signals; evidence before claims.
+5. Separate planning from building; the plan is disposable.
+6. Writer ≠ checker; the checker is fresh, tool-restricted, ideally a different model.
+7. Cap everything: iterations, wall-clock, tokens, retries, concurrency.
+8. Every observed failure becomes a permanent sign; prune stale signs.
+9. Irreversible actions break the loop to a human; autonomy is earned in cycles, not
+   granted.
+10. The operator sits on the loop — watching failure classes and upgrading the
+    system between runs is where the leverage is.
+
+## Where they disagree (and what this skill family chose)
+
+- **Fresh vs warm context.** Huntley: always fresh. Steinberger: warm sessions with
+  strong models, serialize tasks. *Chosen:* fresh per iteration for unattended loops
+  (the failure mode of warm — context rot — is silent; the cost of fresh — re-reading —
+  is visible and bounded).
+- **Full autonomy vs human taste.** Huntley optimizes for unattended weeks;
+  Steinberger keeps the human as evaluator. *Chosen:* both, staged — propose-only
+  loops run unattended, write access is earned through checker-verified clean cycles
+  plus human approval, and taste checkpoints are chartered.
+- **Revert vs morph forward.** This family reverts regressions (ratchet discipline);
+  Steinberger never reverts, morphs forward. *Chosen:* revert inside unattended
+  iterations (no human present to steer a morph), morph in attended sessions.

--- a/free-skills/loop-designer/references/loop-charter-template.md
+++ b/free-skills/loop-designer/references/loop-charter-template.md
@@ -1,0 +1,74 @@
+# LOOP.md charter template
+
+Copy this into `.loop/<name>/LOOP.md` and fill every section. Section headings are
+parse-stable: loop-runner and loop-orchestrator locate them by exact name — do not
+rename or reorder them. Keep the whole charter under ~120 lines; it is re-read at the
+top of every iteration and competes with the actual work for context.
+
+```markdown
+# Loop: <name>
+
+## Goal
+<One sentence, outcome-shaped, stable across weeks.>
+
+## Done-when
+<Mechanically checkable predicate. Command(s) + expected result, or countable file
+state. Example: `python3 scripts/validate_skills.py` exits 0 AND backlog.md has no
+unchecked items.>
+
+## Archetype
+<backlog-drain | ratchet-climb | red-green | watch-and-report | evaluate-optimize |
+babysitter | pipeline> — <one line on the hybrid, if any>
+
+## Iteration contract
+- Unit: <what exactly one iteration completes — one backlog item / one test / one page>
+- Start: read state.json, journal.md (last 3 entries), backlog.md; pick the top
+  eligible unit.
+- End: unit verified + recorded, working tree clean or committed, state.json updated.
+- Never: start a second unit, leave uncommitted mid-work, mark unverified work done.
+
+## Verification
+<Exact commands with expected outcomes. These run INSIDE every iteration.>
+- `<command>` → <expected>
+- `<command>` → <expected>
+
+## Ratchet
+- Metric: <e.g. unchecked backlog items | failing tests | audit score>
+- Direction: <decreasing | increasing>
+- Read via: `<command or file>`
+- On regression: revert the iteration's changes, journal the regression, do not retry
+  the same approach.
+
+## Guardrails
+<Inherited repo hard-stops plus loop-specific never-dos. Explicit verbs: no deploy,
+no publish, no send, no delete outside <path>, no spend, no force-push, no touching
+<protected paths>.>
+
+## Escalation
+- Stalled: <K> iterations without ratchet movement (default 3) → set status
+  "stalled", write journal entry with the blocker, <how to notify the operator:
+  Slack DM / PR comment / file in inbox/>.
+- Blocked on a decision: never guess on <list decision classes> — stop and escalate.
+
+## Budget
+- Max iterations: <N>
+- Max wall-clock per iteration: <minutes>
+- Cadence: <how often iterations fire — on-demand / every 30m / daily HH:MM>
+
+## Promotion
+- Current mode: propose-only  <!-- propose-only | write-scoped | write-full -->
+- Write access requires: <N=3> consecutive clean cycles (verified, no regressions,
+  no guardrail violations) reviewed by <who>.
+- Write scope when promoted: <exact paths / actions unlocked>.
+```
+
+## Filling notes
+
+- **Done-when vs Ratchet**: done-when is binary and final; the ratchet is the progress
+  scalar. Every charter needs both — done-when alone can't detect stall, ratchet
+  alone can't terminate.
+- **Verification commands must run in the loop's own repo/environment.** The designer
+  runs each one once at design time (loop-doctor step) — a charter with untested
+  verification is invalid.
+- **Escalation must name a channel that reaches a human**, not "report in the log".
+  Logs are where escalations go to die.

--- a/free-skills/loop-designer/references/loop-doctor.md
+++ b/free-skills/loop-designer/references/loop-doctor.md
@@ -15,22 +15,22 @@ fails any REQUIRED check must not be started.
 | D5 | Units sized | spot-check 3 backlog items: each completable + verifiable in one fresh-context session | split oversized items in backlog.md |
 | D6 | Guardrails inherited | charter Guardrails include the repo's hard-stops (check CLAUDE.md / AGENTS.md) | copy them in explicitly |
 | D7 | Escalation reaches a human | Escalation names a real channel (Slack/PR/inbox), not just the journal | wire a channel |
-| D8 | Propose-only start | state.json `promotion.mode` is `propose-only` for any loop that could write/publish/send | reset mode |
-| D9 | Budget declared | max_iterations, per-iteration wall-clock, cadence all set | set them |
+| D8 | Propose-only start | `.loop/<name>/state.json` `promotion.mode` is `propose-only` for any loop that could write/publish/send | reset mode |
+| D9 | Budget declared | `budget.max_iterations`, `budget.max_minutes_per_iteration`, `budget.cadence` all set | set them |
 
 ## HEALTH — runtime (run when a loop looks sick)
 
 | # | Check | Symptom it catches |
 |---|---|---|
-| H1 | journal entry per iteration (`iteration` in state.json == entry count) | silent iterations — work happening off the books |
-| H2 | `ratchet.value` moved within last `stall_threshold` iterations | spinning without progress |
+| H1 | journal entry per iteration (`iteration` in `.loop/<name>/state.json` == entry count) | silent iterations — work happening off the books |
+| H2 | `ratchet.value` moved within last `ratchet.stall_threshold` iterations | spinning without progress |
 | H3 | No ❌ verify in last 3 entries without a matching revert/escalation flag | failures being absorbed instead of handled |
 | H4 | Working tree clean between iterations | debris — a prior iteration died mid-unit |
-| H5 | `clean_cycles` math consistent with journal flags | promotion gate being gamed by sloppy bookkeeping |
+| H5 | `promotion.clean_cycles` math consistent with journal flags | promotion gate being gamed by sloppy bookkeeping |
 | H6 | Iterations within wall-clock budget (journal timestamps) | units too big — return to D5 |
 | H7 | Same unit not picked >2 iterations in a row without a Flags note | thrash on one item; force-skip and escalate it |
-| H8 | Every ❌ journal entry with an identifiable cause has a matching sign in signs.md | failures not being converted into immunity — the loop will repeat them |
-| H9 | signs.md under ~40 lines and free of speculative entries | sign bloat polluting every iteration's context |
+| H8 | Every ❌ journal entry with an identifiable cause has a matching sign in `.loop/<name>/signs.md` | failures not being converted into immunity — the loop will repeat them |
+| H9 | `.loop/<name>/signs.md` under ~40 lines and free of speculative entries | sign bloat polluting every iteration's context |
 
 ## Verdict format
 

--- a/free-skills/loop-designer/references/loop-doctor.md
+++ b/free-skills/loop-designer/references/loop-doctor.md
@@ -29,6 +29,8 @@ fails any REQUIRED check must not be started.
 | H5 | `clean_cycles` math consistent with journal flags | promotion gate being gamed by sloppy bookkeeping |
 | H6 | Iterations within wall-clock budget (journal timestamps) | units too big — return to D5 |
 | H7 | Same unit not picked >2 iterations in a row without a Flags note | thrash on one item; force-skip and escalate it |
+| H8 | Every ❌ journal entry with an identifiable cause has a matching sign in signs.md | failures not being converted into immunity — the loop will repeat them |
+| H9 | signs.md under ~40 lines and free of speculative entries | sign bloat polluting every iteration's context |
 
 ## Verdict format
 

--- a/free-skills/loop-designer/references/loop-doctor.md
+++ b/free-skills/loop-designer/references/loop-doctor.md
@@ -1,0 +1,37 @@
+# Loop doctor — pre-flight and health checks
+
+Run these checks (a) at design time before handing a loop to the user, and (b) any
+time a loop misbehaves. Each check is pass/fail with a specific fix. A loop that
+fails any REQUIRED check must not be started.
+
+## REQUIRED — design validity
+
+| # | Check | How | Fix on fail |
+|---|---|---|---|
+| D1 | Charter parses | `.loop/<name>/LOOP.md` exists with every template section present, exact headings | re-emit from template |
+| D2 | Done-when is mechanical | done-when names command(s)/countable state, no judgment words ("good", "clean", "polished") | narrow the goal with the user |
+| D3 | Verification runs | execute each Verification command once, here, now | fix command or environment; never hand off untested |
+| D4 | Ratchet readable | the "Read via" command returns the metric | fix command |
+| D5 | Units sized | spot-check 3 backlog items: each completable + verifiable in one fresh-context session | split oversized items in backlog.md |
+| D6 | Guardrails inherited | charter Guardrails include the repo's hard-stops (check CLAUDE.md / AGENTS.md) | copy them in explicitly |
+| D7 | Escalation reaches a human | Escalation names a real channel (Slack/PR/inbox), not just the journal | wire a channel |
+| D8 | Propose-only start | state.json `promotion.mode` is `propose-only` for any loop that could write/publish/send | reset mode |
+| D9 | Budget declared | max_iterations, per-iteration wall-clock, cadence all set | set them |
+
+## HEALTH — runtime (run when a loop looks sick)
+
+| # | Check | Symptom it catches |
+|---|---|---|
+| H1 | journal entry per iteration (`iteration` in state.json == entry count) | silent iterations — work happening off the books |
+| H2 | `ratchet.value` moved within last `stall_threshold` iterations | spinning without progress |
+| H3 | No ❌ verify in last 3 entries without a matching revert/escalation flag | failures being absorbed instead of handled |
+| H4 | Working tree clean between iterations | debris — a prior iteration died mid-unit |
+| H5 | `clean_cycles` math consistent with journal flags | promotion gate being gamed by sloppy bookkeeping |
+| H6 | Iterations within wall-clock budget (journal timestamps) | units too big — return to D5 |
+| H7 | Same unit not picked >2 iterations in a row without a Flags note | thrash on one item; force-skip and escalate it |
+
+## Verdict format
+
+Report as: `Loop doctor: PASS` or `Loop doctor: FAIL — D3, D7` plus one line per
+failure with the fix. Health runs report `HEALTH: OK` or the failing H-checks the
+same way.

--- a/free-skills/loop-designer/references/loop-native-skills.md
+++ b/free-skills/loop-designer/references/loop-native-skills.md
@@ -1,0 +1,75 @@
+# Loop-native skills — guidance for skill-creator and plugin-creator
+
+How skills and loops compose, and what a skill author changes when the caller is a
+loop instead of a human. Absorb this into any skill-creator / plugin-creator
+workflow: the unit of agentic work is shifting from *prompt* to *loop*, and skills
+are the subroutines loops call.
+
+## The composition model
+
+```
+loop-designer  → compiles a goal into .loop/<name>/   (the program)
+loop-runner    → executes one iteration                (the interpreter)
+loop-orchestrator → schedules the fleet                (the kernel)
+skills         → capabilities an iteration invokes     (the standard library)
+```
+
+A charter's Iteration contract and Verification sections routinely name skills
+("polish via content-polisher, gate via integrity-guard"). That makes skill quality a
+loop-convergence issue: a skill that returns vague results stalls every loop that
+calls it.
+
+## Authoring rules for loop-callable skills
+
+1. **Machine-checkable outcomes.** A loop's Verify step needs pass/fail it can read.
+   Skills should state their success predicate ("done when `validate.py` exits 0",
+   "returns verdict: pass|warn|fail") — not "review the output for quality".
+2. **Idempotent and resumable.** Iterations die mid-flight. A skill invoked twice on
+   the same input must not corrupt state; partial completion must be detectable
+   (files-first design: write artifacts, then a completion marker, in that order).
+3. **Evidence-shaped returns.** Return actual command output, counts, paths — the
+   runner journals evidence, not summaries. "214 tests passed, 0 failed" beats
+   "tests look good".
+4. **Declare side-effect class in the description.** Loops enforce promotion gates
+   (propose-only → write). A skill that publishes/sends/deploys must say so in its
+   frontmatter description so a propose-only iteration refuses it. For manual-only
+   side effects, set `disable-model-invocation: true` where the harness supports it.
+5. **Bounded per invocation.** One skill call must fit inside one iteration's
+   wall-clock budget. Skills that fan out unboundedly ("audit every page") should
+   take a scope argument so the loop can pass one unit at a time.
+6. **Verbose, actionable failures.** "Field X missing; available: A, B, C" lets the
+   next iteration self-correct; a bare stack trace burns an iteration on diagnosis.
+
+## What skill-creator itself should add (the eval loop)
+
+Skill authoring is itself an evaluate-optimize loop — run it as one:
+
+1. **Evals before docs.** Before writing SKILL.md, write ≥3 realistic trigger
+   prompts + objectively checkable assertions for each (what files exist after, what
+   the output contains).
+2. **Baseline first.** Run the evals *without* the skill; write only the minimal
+   instructions that close the observed gap. If the bare model already passes, the
+   skill section is dead weight — cut it.
+3. **Author/tester split.** One fresh context authors; a different fresh context
+   runs the evals (same maker/checker rule loops use — the author grading its own
+   skill is too generous). Watch actual navigation: missed links, ignored reference
+   files, over-read files → restructure.
+4. **Optimize the description last.** It is the only routing signal; tune it against
+   trigger accuracy (does the skill fire on the eval prompts and stay quiet
+   otherwise?), not against elegance.
+5. **Ratchet the iterations.** Keep eval scores per revision; a revision that scores
+   lower gets reverted, not argued for.
+
+## What plugin-creator should add
+
+Plugins bundle skills + commands + hooks + agents. Loop-native additions:
+
+- **Ship the loop, not just the skill.** If a plugin automates recurring work, include
+  a `.loop/` charter template for it (a designed loop) rather than a bare "run me
+  daily" note — cadence without discipline is how automations rot into unread logs.
+- **Hooks are the deterministic tier.** Anything that must happen every time
+  (format-on-write, commit-on-stop, evidence gates, protected-path blocks) belongs in
+  a hook, not in skill prose. Skills advise; hooks guarantee.
+- **Declare an operator surface.** Where do this plugin's automations report, and
+  where does a human steer or stop them? A plugin that runs unattended without a
+  report channel and a kill switch fails review.

--- a/free-skills/loop-designer/references/state-schema.md
+++ b/free-skills/loop-designer/references/state-schema.md
@@ -84,3 +84,19 @@ Rules:
   good".
 - Never rewrite or delete old entries — the journal is the loop's memory and audit
   trail. Corrections are new entries.
+
+## signs.md
+
+The loop's accumulated immune system — one binding rule per line, each earned from an
+observed failure. Read by the runner every iteration at Guardrails tier; appended by
+the runner whenever a failure has an identifiable cause; pruned by the designer when
+a sign goes stale (obsolete after a refactor or a model upgrade). Format:
+
+```markdown
+- <date> · do not edit files under gen/ — regenerate via `pnpm gen` (edit was clobbered, it.7)
+- <date> · run db migrations before the type check (it.12 failed on stale types)
+```
+
+Keep it under ~40 lines — a bloated signs file pollutes every future iteration; if it
+grows past that, the top offenders belong upstream (fix the code the loop imitates,
+or the charter).

--- a/free-skills/loop-designer/references/state-schema.md
+++ b/free-skills/loop-designer/references/state-schema.md
@@ -1,0 +1,86 @@
+# state.json schema + journal.md format
+
+## state.json
+
+Machine-readable loop state. The runner updates it at the end of every iteration;
+the orchestrator reads it to schedule. Keep it small — it is a dashboard row, not a
+database.
+
+```json
+{
+  "name": "hub-a11y-drain",
+  "archetype": "backlog-drain",
+  "status": "designed",
+  "iteration": 0,
+  "ratchet": {
+    "metric": "unchecked backlog items",
+    "direction": "decreasing",
+    "value": 40,
+    "best": 40,
+    "stall_count": 0,
+    "stall_threshold": 3
+  },
+  "promotion": {
+    "mode": "propose-only",
+    "clean_cycles": 0,
+    "required_cycles": 3,
+    "write_scope": []
+  },
+  "budget": {
+    "max_iterations": 60,
+    "max_minutes_per_iteration": 20,
+    "cadence": "every 30m"
+  },
+  "last_run": null,
+  "last_agent": null,
+  "created": "<ISO date>",
+  "notes": ""
+}
+```
+
+### status values
+
+| status | meaning | set by |
+|---|---|---|
+| `designed` | charter written, never run | designer |
+| `active` | eligible for iterations | operator or orchestrator |
+| `paused` | intentionally not running | operator |
+| `stalled` | stall_threshold hit — needs human | runner |
+| `blocked` | waiting on an escalated decision | runner |
+| `done` | done-when predicate satisfied | runner |
+| `retired` | superseded / abandoned, kept for the journal | operator |
+
+### Field rules
+
+- `ratchet.value` is written every iteration from the charter's "Read via" command —
+  never estimated. `best` tracks the high-water mark; `value` worse than `best` for a
+  completed iteration means a regression happened and was not reverted → the runner
+  must treat that as a failed iteration.
+- `promotion.clean_cycles` resets to 0 on any regression, guardrail violation, or
+  failed verification. It only counts *consecutive* clean cycles.
+- `last_agent` records which harness ran the iteration (`claude-code`, `codex`,
+  `gemini`, `grok`, …) — useful when loops behave differently per agent.
+
+## journal.md
+
+Append-only, newest entry last. One entry per iteration, written at the END of the
+iteration (an iteration with no journal entry did not happen). Format:
+
+```markdown
+## <iteration N> · <ISO timestamp> · <agent>
+- Unit: <what was picked>
+- Did: <1-3 lines, concrete — files touched, commands run>
+- Verify: <command → actual result>  ✅ | ❌
+- Ratchet: <old> → <new>
+- Next: <what the next iteration should pick, or "top of backlog">
+- Flags: <regression reverted / guardrail near-miss / escalated / none>
+```
+
+Rules:
+
+- **Max ~10 lines per entry.** The next iteration reads only the last 3 entries; a
+  journal that rambles starves the work of context.
+- **Evidence over narrative.** "Verify: `pnpm test` → 214 passed" beats "tests look
+  good".
+- Never rewrite or delete old entries — the journal is the loop's memory and audit
+  trail. Corrections are new entries.

--- a/free-skills/loop-orchestrator/SKILL.md
+++ b/free-skills/loop-orchestrator/SKILL.md
@@ -29,6 +29,8 @@ Pick the next loop(s) to run. Priority order:
 1. `blocked`/`stalled` loops whose escalation was answered — unblock them first (update state, write the operator's decision into the journal, set `active`).
 2. Loops whose cadence is due, ordered by: babysitters and watch-and-report first (cheap, time-sensitive), then the loop closest to `done` (finish lines beat new fronts), then highest-priority per the fleet's own backlog if one exists.
 3. Never schedule two loops that write to overlapping paths concurrently — serialize them (check charters' write scopes; last-write-wins clobbers are silent).
+4. Apply backpressure: defer cadence-due monitors while a write loop is mid-iteration in the same repo; respect the fleet's active-hours window if one is set; exact-time isolated jobs (cron-style, fresh session, audit record) and batched context-aware checks (heartbeat-style) are different mechanisms — don't merge them into one mega-pass.
+5. A loop whose journal shows circling (same units reappearing, ratchet flat) gets a **backlog regeneration** dispatched through loop-designer instead of another iteration — one planning pass is cheaper than ten circling build passes.
 
 Dispatch one iteration per scheduled loop via the loop-runner skill in a **fresh context** (subagent, `claude -p`, or `codex exec` — see harness table in loop-runner). You may run non-overlapping loops in parallel.
 

--- a/free-skills/loop-orchestrator/SKILL.md
+++ b/free-skills/loop-orchestrator/SKILL.md
@@ -13,13 +13,13 @@ You run the fleet, not the iterations. The designer compiles loops, the runner e
 
 Read every `.loop/*/state.json` (skip `retired`). Build the fleet table:
 
-`name · archetype · status · iteration/budget · ratchet value→best · stall_count · promotion mode · clean_cycles/required · last_run · last_agent`
+`name · archetype · status · iteration/budget.max_iterations · ratchet.value→ratchet.best · ratchet.stall_count · promotion.mode · promotion.clean_cycles/promotion.required_cycles · last_run · last_agent`
 
 Flag immediately, before any scheduling:
 
-- **Dead loop** — `active` but `last_run` older than 2× its cadence. A dead monitor is worse than no monitor: escalate.
+- **Dead loop** — `active` but `last_run` older than 2× its `budget.cadence`. A dead monitor is worse than no monitor: escalate.
 - **Stalled/blocked** — needs a human decision; surface at the top of every report until resolved.
-- **Budget-exhausted** — `iteration >= max_iterations` while not `done`: candidate for redesign (unit sizing was wrong) or retirement.
+- **Budget-exhausted** — `iteration >= budget.max_iterations` while not `done`: candidate for redesign (unit sizing was wrong) or retirement.
 - **Debris** — dirty working tree attributable to a loop (runner gate H4): adjudicate — revert debris or convert it into a backlog item, journal the adjudication in that loop's journal.
 
 ### 2 · Schedule
@@ -50,8 +50,8 @@ Typical assignment when multiple harnesses are available: strongest/cheapest-ade
 The gate is the core safety mechanism — guard it:
 
 - Every loop starts `propose-only`. Its commits go to branches/PRs/staged diffs; nothing lands on protected surfaces.
-- Promotion to `write-scoped` requires: `clean_cycles >= required_cycles` (consecutive, checker-verified) **AND explicit human approval** recorded in the journal with who/when. You prepare the promotion case (evidence links, cycle history); you do not approve it.
-- Any regression, guardrail violation, or failed verification after promotion → **automatic demotion** to `propose-only`, `clean_cycles: 0`, journal entry, escalation. Demotion is yours to execute without asking.
+- Promotion to `write-scoped` requires: `promotion.clean_cycles >= promotion.required_cycles` (consecutive, checker-verified) **AND explicit human approval** recorded in the journal with who/when. You prepare the promotion case (evidence links, cycle history); you do not approve it.
+- Any regression, guardrail violation, or failed verification after promotion → **automatic demotion** to `propose-only`, `promotion.clean_cycles: 0`, journal entry, escalation. Demotion is yours to execute without asking.
 - `write-scoped` unlocks only the charter's declared write scope. There is no fleet-wide write-full.
 
 ### 5 · Operate the control surfaces

--- a/free-skills/loop-orchestrator/SKILL.md
+++ b/free-skills/loop-orchestrator/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: loop-orchestrator
+description: Operate a fleet of durable agent loops under .loop/ — schedule which loop runs next, assign agents to roles (maker vs checker), enforce promotion gates from propose-only to write access, allocate budgets, detect stalled or dead loops, and roll up fleet status into one report. Use when asked to "run the loops", "orchestrate the loops", "loop status", "which loop next", "promote the loop", or to manage 24/7 loop operations across Claude Code, Codex, Gemini, and Grok.
+---
+
+# Loop Orchestrator
+
+You run the fleet, not the iterations. The designer compiles loops, the runner executes single iterations; you decide **which loop runs, with which agent, under which permissions, and when a human must look**. Your state is the union of every `.loop/*/state.json` — you own no work of your own, and you never do a loop's work for it.
+
+## Fleet operations
+
+### 1 · Survey
+
+Read every `.loop/*/state.json` (skip `retired`). Build the fleet table:
+
+`name · archetype · status · iteration/budget · ratchet value→best · stall_count · promotion mode · clean_cycles/required · last_run · last_agent`
+
+Flag immediately, before any scheduling:
+
+- **Dead loop** — `active` but `last_run` older than 2× its cadence. A dead monitor is worse than no monitor: escalate.
+- **Stalled/blocked** — needs a human decision; surface at the top of every report until resolved.
+- **Budget-exhausted** — `iteration >= max_iterations` while not `done`: candidate for redesign (unit sizing was wrong) or retirement.
+- **Debris** — dirty working tree attributable to a loop (runner gate H4): adjudicate — revert debris or convert it into a backlog item, journal the adjudication in that loop's journal.
+
+### 2 · Schedule
+
+Pick the next loop(s) to run. Priority order:
+
+1. `blocked`/`stalled` loops whose escalation was answered — unblock them first (update state, write the operator's decision into the journal, set `active`).
+2. Loops whose cadence is due, ordered by: babysitters and watch-and-report first (cheap, time-sensitive), then the loop closest to `done` (finish lines beat new fronts), then highest-priority per the fleet's own backlog if one exists.
+3. Never schedule two loops that write to overlapping paths concurrently — serialize them (check charters' write scopes; last-write-wins clobbers are silent).
+
+Dispatch one iteration per scheduled loop via the loop-runner skill in a **fresh context** (subagent, `claude -p`, or `codex exec` — see harness table in loop-runner). You may run non-overlapping loops in parallel.
+
+### 3 · Assign roles (maker / checker)
+
+For any loop whose charter names a checker, enforce the split — the agent that made the change never grades it:
+
+- **Maker** runs the iteration (steps 0–5 of the runner protocol).
+- **Checker** is a fresh context, *different model or harness where available*, with **no write tools**, that re-runs Verification and reviews the diff against the charter. Verdict: `PASS` or `NEEDS_WORK: <specific findings>`. Findings go into the loop's journal and become the next iteration's unit.
+- A `clean_cycle` only counts when the checker (not the maker) said PASS.
+- Restrict checkers to correctness and charter compliance — a reviewer told to find problems always finds some; style nits are not findings.
+
+Typical assignment when multiple harnesses are available: strongest/cheapest-adequate model as maker per loop archetype; a *different* vendor's model as checker; adversarial-taste reviews to whichever agent the fleet designates as critic.
+
+### 4 · Enforce promotion gates
+
+The gate is the core safety mechanism — guard it:
+
+- Every loop starts `propose-only`. Its commits go to branches/PRs/staged diffs; nothing lands on protected surfaces.
+- Promotion to `write-scoped` requires: `clean_cycles >= required_cycles` (consecutive, checker-verified) **AND explicit human approval** recorded in the journal with who/when. You prepare the promotion case (evidence links, cycle history); you do not approve it.
+- Any regression, guardrail violation, or failed verification after promotion → **automatic demotion** to `propose-only`, `clean_cycles: 0`, journal entry, escalation. Demotion is yours to execute without asking.
+- `write-scoped` unlocks only the charter's declared write scope. There is no fleet-wide write-full.
+
+### 5 · Operate the control surfaces
+
+- **STEER file** — before dispatching any iteration, check `.loop/<name>/STEER.md`. If present, inject its content into the runner's instruction ("operator steering: <content>") and delete it after the iteration journals it. This is how a human redirects a running loop without editing the charter.
+- **Kill switch** — if `.loop/STOP` (fleet-wide) or `.loop/<name>/STOP` exists, dispatch nothing for that scope; report which loops were held. Never delete a STOP file yourself.
+- **Budgets** — track fleet spend across a session; when the operator sets a total budget, allocate by loop priority and stop dispatching when spent, reporting what got cut.
+
+### 6 · Report
+
+End every orchestration pass with one rollup (this is the fleet's delivery surface — send it wherever the operator reads, per the fleet's escalation channel; a report only in the transcript is a silent failure):
+
+```
+LOOP FLEET · <date>
+⏸ needs-human: <loop> — <one-line reason + what decision is needed>
+▶ ran: <loop> it.N <unit> ✅/❌ ratchet X→Y (maker: <agent>, checker: PASS/NEEDS_WORK)
+⏭ due-next: <loop> at <time>
+🎯 promotions: <loop> N/M clean cycles (case ready | not yet)
+💀 dead/stalled: <loop> — <age / stall count>
+```
+
+## Hard rules
+
+1. **You never do a loop's work.** If a loop's unit is tempting to "just fix", dispatch an iteration instead. Orchestrator context stays small on purpose.
+2. **You never edit charters.** Redesigns go back through loop-designer; you can retire, pause, demote, and adjudicate debris.
+3. **Human gates are load-bearing.** Promotion, un-stalling, and STOP-file removal are operator actions. Prepare cases; don't self-approve.
+4. **Serialize overlapping write scopes.** Two agents in one working tree is the silent-clobber failure mode.
+5. **Every pass produces the rollup report** — even "nothing due, all healthy". Cadence trust is built by boring reports.
+
+## Bootstrapping a fleet
+
+No `.loop/` yet? Route to loop-designer for each goal first. Migrating ad-hoc automations (crons, routines, scheduled prompts) into loops: wrap each as watch-and-report first (propose-only by construction), let it earn cycles, then promote — never port an automation straight to write access, even one that "already had" it.

--- a/free-skills/loop-runner/SKILL.md
+++ b/free-skills/loop-runner/SKILL.md
@@ -13,9 +13,11 @@ Execute in order. Do not skip, reorder, or batch steps.
 
 ### 0 · Load
 
-Read, in this order: `.loop/<name>/LOOP.md` (the whole charter), `state.json`, the
-**last 3 entries** of `journal.md`, and `backlog.md` if the archetype uses one. Do
-not read the full journal — old entries are archive, not context.
+Read, in this order: `.loop/<name>/LOOP.md` (the whole charter), `signs.md` (every
+line is a binding rule earned from a past failure — treat them like Guardrails),
+`state.json`, the **last 3 entries** of `journal.md`, and `backlog.md` if the
+archetype uses one. Do not read the full journal — old entries are archive, not
+context.
 
 ### 1 · Gate
 
@@ -66,6 +68,13 @@ nothing failed.
   regression with the ❌ flag. Do not debug forward. Do not leave the regression for
   the next iteration.
 - Verification fails → fix within budget or revert. Never record a ❌ unit as done.
+- Any failure with an identifiable cause → append one line to `signs.md`: a rule that
+  would have prevented it ("do not edit generated files under X — regenerate",
+  "run the schema migration before the type check"). Signs come only from observed
+  failures — never add speculative ones.
+- You overran the wall-clock budget noticeably? Treat it as a drift alarm even if
+  verification passed — journal what made the unit slow; it usually means a wrong
+  mental model or an oversized unit (propose the split in `Next:`).
 
 ### 5 · Record
 
@@ -84,9 +93,16 @@ state with no evidence):
 
 ### 6 · Report & handoff
 
-- `stall_count >= stall_threshold` → set `status: stalled` and escalate per the
-  charter's Escalation channel — a real message to a human, not a journal line.
+- `stall_count >= stall_threshold` → before escalating to a human, take one
+  in-loop escalation if the charter allows it: hand the blocker (files + failed
+  approaches from the journal) to a stronger reasoner or a fresh different-vendor
+  model for a hypothesis. If that iteration also fails → set `status: stalled` and
+  escalate per the charter's Escalation channel — a real message to a human, not a
+  journal line. Recommend a backlog regeneration if the journal shows circling.
 - Done-when now passes → `status: done`, escalate the good news the same way.
+- Nothing needed attention (watch loops, no-change cycles) → reply exactly the
+  charter's OK-token (default `LOOP_OK`) and suppress any channel report — the
+  silence contract is what keeps the human reading the reports that matter.
 - Otherwise: one-line report (`iteration N: <unit> ✅, ratchet X→Y, next: <unit>`)
   and stop. **Never start iteration N+1 yourself** — cadence belongs to the
   scheduler (cron, /loop, while-loop, orchestrator), not to you.

--- a/free-skills/loop-runner/SKILL.md
+++ b/free-skills/loop-runner/SKILL.md
@@ -13,11 +13,11 @@ Execute in order. Do not skip, reorder, or batch steps.
 
 ### 0 · Load
 
-Read, in this order: `.loop/<name>/LOOP.md` (the whole charter), `signs.md` (every
-line is a binding rule earned from a past failure — treat them like Guardrails),
-`state.json`, the **last 3 entries** of `journal.md`, and `backlog.md` if the
-archetype uses one. Do not read the full journal — old entries are archive, not
-context.
+Read, in this order: `.loop/<name>/LOOP.md` (the whole charter), `.loop/<name>/signs.md`
+(every line is a binding rule earned from a past failure — treat them like
+Guardrails), `.loop/<name>/state.json`, the **last 3 entries** of
+`.loop/<name>/journal.md`, and `.loop/<name>/backlog.md` if the archetype uses one.
+Do not read the full journal — old entries are archive, not context.
 
 ### 1 · Gate
 
@@ -68,7 +68,7 @@ nothing failed.
   regression with the ❌ flag. Do not debug forward. Do not leave the regression for
   the next iteration.
 - Verification fails → fix within budget or revert. Never record a ❌ unit as done.
-- Any failure with an identifiable cause → append one line to `signs.md`: a rule that
+- Any failure with an identifiable cause → append one line to `.loop/<name>/signs.md`: a rule that
   would have prevented it ("do not edit generated files under X — regenerate",
   "run the schema migration before the type check"). Signs come only from observed
   failures — never add speculative ones.
@@ -81,19 +81,21 @@ nothing failed.
 In this order (order matters — a crash between steps must never leave done-looking
 state with no evidence):
 
-1. Append the journal entry (format in the loop's `state-schema` reference — Unit /
-   Did / Verify with actual command output / Ratchet old→new / Next / Flags).
-2. Update `state.json`: `iteration+1`, `ratchet.value` (and `best`), `stall_count`
-   (0 if moved, +1 if not), `clean_cycles` (+1 if clean; reset to 0 on any ❌,
-   regression, or guardrail near-miss), `last_run`, `last_agent`.
-3. Strike through / advance the unit in `backlog.md`.
+1. Append the journal entry to `.loop/<name>/journal.md` (format in the loop's
+   `state-schema` reference — Unit / Did / Verify with actual command output /
+   Ratchet old→new / Next / Flags).
+2. Update `.loop/<name>/state.json`: `iteration+1`, `ratchet.value` (and
+   `ratchet.best`), `ratchet.stall_count` (0 if moved, +1 if not),
+   `promotion.clean_cycles` (+1 if clean; reset to 0 on any ❌, regression, or
+   guardrail near-miss), `last_run`, `last_agent`.
+3. Strike through / advance the unit in `.loop/<name>/backlog.md`.
 4. Commit if the loop's promotion mode allows it; otherwise leave the change as a
    proposal per the charter (branch, PR, or staged diff — whatever the charter says).
    Working tree must end clean-or-committed either way.
 
 ### 6 · Report & handoff
 
-- `stall_count >= stall_threshold` → before escalating to a human, take one
+- `ratchet.stall_count >= ratchet.stall_threshold` → before escalating to a human, take one
   in-loop escalation if the charter allows it: hand the blocker (files + failed
   approaches from the journal) to a stronger reasoner or a fresh different-vendor
   model for a hypothesis. If that iteration also fails → set `status: stalled` and
@@ -110,8 +112,8 @@ state with no evidence):
 ## Hard rules
 
 1. **One unit per iteration.** The loop's convergence proof depends on it.
-2. **Files are the only memory.** Anything worth knowing goes in journal/state/backlog
-   before you exit.
+2. **Files are the only memory.** Anything worth knowing goes in `.loop/<name>/`
+   (journal/state/backlog/signs) before you exit.
 3. **Propose-only means propose-only.** If `promotion.mode` is `propose-only`, you do
    not commit to protected branches, publish, send, deploy, or spend — no matter what
    the unit seems to need. The gate is the point.

--- a/free-skills/loop-runner/SKILL.md
+++ b/free-skills/loop-runner/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: loop-runner
+description: Execute exactly one disciplined iteration of a designed loop from .loop/<name>/ (LOOP.md charter + state.json + journal.md). Use when asked to "run the loop", "run one iteration of <loop>", "continue the <name> loop", or when invoked on a cadence (cron, /loop, while-loop) against a loop directory. Works identically under Claude Code, Codex, Gemini CLI, or any coding agent — state lives in files, not in this conversation.
+---
+
+# Loop Runner
+
+You are one iteration of a durable loop. You start cold, you finish clean, and everything you learn goes into files — the next iteration (possibly a different agent, possibly you tomorrow) knows only what the loop directory says. Run **exactly one unit**; resist finishing "just one more".
+
+## The iteration protocol
+
+Execute in order. Do not skip, reorder, or batch steps.
+
+### 0 · Load
+
+Read, in this order: `.loop/<name>/LOOP.md` (the whole charter), `state.json`, the
+**last 3 entries** of `journal.md`, and `backlog.md` if the archetype uses one. Do
+not read the full journal — old entries are archive, not context.
+
+### 1 · Gate
+
+Refuse to run (exit with one journal line explaining why) if ANY of:
+
+- `.loop/STOP` or `.loop/<name>/STOP` exists — the operator's kill switch. Never
+  delete a STOP file.
+- `status` is `paused`, `stalled`, `blocked`, `done`, or `retired` — only an operator
+  or the orchestrator changes those.
+- `iteration >= budget.max_iterations`.
+- Done-when already passes → set `status: done`, journal it, report, stop.
+- The working tree is dirty with changes this loop didn't journal → set `status:
+  blocked`, escalate per charter (H4 debris — a prior iteration died; a human or the
+  orchestrator must adjudicate, not you).
+
+Then check `.loop/<name>/STEER.md`. If present, it is live operator steering:
+incorporate it into this iteration's choices, quote it in the journal entry, then
+delete the file. Steering outranks the journal's `Next:` hint but never overrides
+Guardrails or promotion mode.
+
+### 2 · Pick
+
+Select the single unit per the charter's Iteration contract (top eligible backlog
+item; next failing test; the current blocker for a babysitter; …). If the last
+journal entry's `Next:` names a unit, prefer it unless it's now ineligible. If the
+same unit appears in the last 2 entries with ❌, you MUST take a different approach
+or escalate — never re-run a failed approach verbatim.
+
+### 3 · Do
+
+Complete the unit within the charter's Guardrails and wall-clock budget. Touch only
+what the unit requires. If mid-unit you discover it's oversized, stop at a coherent
+boundary, split the remainder into new backlog items, and treat the completed part as
+your unit.
+
+### 4 · Verify
+
+Run every command in the charter's Verification section and read the ratchet via its
+"Read via" command. This step is not optional and not skippable under time pressure —
+an unverified unit is a failed unit. **Evidence, not assertions**: the journal gets
+the actual command output (exit code, counts, failing test names), never "tests
+pass". You may not record a result you did not observe this iteration. An iteration
+that produced no changes counts as no ratchet movement (`stall_count+1`), even if
+nothing failed.
+
+- All pass + ratchet moved right (or held, for non-ratchet units) → proceed.
+- Ratchet regressed → **revert your changes now** (git restore / revert), journal the
+  regression with the ❌ flag. Do not debug forward. Do not leave the regression for
+  the next iteration.
+- Verification fails → fix within budget or revert. Never record a ❌ unit as done.
+
+### 5 · Record
+
+In this order (order matters — a crash between steps must never leave done-looking
+state with no evidence):
+
+1. Append the journal entry (format in the loop's `state-schema` reference — Unit /
+   Did / Verify with actual command output / Ratchet old→new / Next / Flags).
+2. Update `state.json`: `iteration+1`, `ratchet.value` (and `best`), `stall_count`
+   (0 if moved, +1 if not), `clean_cycles` (+1 if clean; reset to 0 on any ❌,
+   regression, or guardrail near-miss), `last_run`, `last_agent`.
+3. Strike through / advance the unit in `backlog.md`.
+4. Commit if the loop's promotion mode allows it; otherwise leave the change as a
+   proposal per the charter (branch, PR, or staged diff — whatever the charter says).
+   Working tree must end clean-or-committed either way.
+
+### 6 · Report & handoff
+
+- `stall_count >= stall_threshold` → set `status: stalled` and escalate per the
+  charter's Escalation channel — a real message to a human, not a journal line.
+- Done-when now passes → `status: done`, escalate the good news the same way.
+- Otherwise: one-line report (`iteration N: <unit> ✅, ratchet X→Y, next: <unit>`)
+  and stop. **Never start iteration N+1 yourself** — cadence belongs to the
+  scheduler (cron, /loop, while-loop, orchestrator), not to you.
+
+## Hard rules
+
+1. **One unit per iteration.** The loop's convergence proof depends on it.
+2. **Files are the only memory.** Anything worth knowing goes in journal/state/backlog
+   before you exit.
+3. **Propose-only means propose-only.** If `promotion.mode` is `propose-only`, you do
+   not commit to protected branches, publish, send, deploy, or spend — no matter what
+   the unit seems to need. The gate is the point.
+4. **Escalations must leave the loop directory.** Slack, PR comment, inbox file —
+   per charter. Journal-only escalation is a silent failure.
+5. **Never edit LOOP.md.** Charter changes are the designer's/operator's job. If the
+   charter is wrong, escalate with the specific defect.
+
+## Running under different harnesses
+
+The protocol is identical everywhere; only the scheduler differs.
+
+| Harness | One iteration | Cadence |
+|---|---|---|
+| Claude Code | `claude -p "run one iteration of .loop/<name> per loop-runner" --output-format json` | native `/loop 30m <same>`, Stop-hook driver, or cron |
+| Codex CLI | `codex exec --sandbox workspace-write --output-last-message /tmp/out.md "run one iteration of .loop/<name> per the loop-runner skill"` | `while :; do codex exec "…"; sleep 1800; done` or cron |
+| Gemini / Grok / other | equivalent one-shot exec with the same instruction | cron / while-loop |
+| Cloud (CCR routines, Actions) | schedule the one-iteration instruction | platform cron |
+
+Driver-loop notes: agent progress streams to stderr, final message to stdout — keep
+stdout clean for the driver to parse. In CI, scope API keys to the single exec
+invocation (never job-level env — repo-controlled code inside the loop can read job
+env). Fresh context per iteration is a feature — do not "optimize" it away by running
+many iterations in one long session; that reintroduces the context rot the loop
+exists to prevent.


### PR DESCRIPTION
## Summary

The unit of agentic work shifts from *prompt* to *loop* — "you shouldn't be prompting coding agents anymore; you should be designing loops that prompt your agents." This PR ships a three-skill family that makes loops a first-class, agent-agnostic primitive: state lives in `.loop/<name>/` files (charter, state, journal, signs, backlog), so Claude Code, Codex, Gemini, and Grok can all run the same loop interchangeably.

**The family (compiler / VM / kernel):**

- **`loop-designer`** — compiles a goal into a durable loop charter: interview → archetype selection (7-archetype taxonomy) → blast-radius iteration sizing → emit `LOOP.md` + `state.json` + `backlog.md` + `signs.md` + `journal.md` → loop-doctor pre-flight (9 design checks, 9 health checks).
- **`loop-runner`** — the 7-step iteration protocol: load → gate (STOP/STEER files, budgets, debris) → pick one unit → do → verify with evidence → record → report/escalate. Fresh context per iteration; exact `claude -p` / `codex exec` driver invocations per harness.
- **`loop-orchestrator`** — fleet operations: survey, schedule with backpressure, maker/checker role split (checker = fresh, write-tool-less, different vendor), promotion gates (propose-only → write-scoped via N consecutive checker-verified clean cycles + human approval; auto-demotion on regression), STEER/STOP control surfaces, rollup reporting.

**Naming:** deliberately does NOT claim `/loop` — Claude Code's native `/loop` is the *timer*; `loop-runner` is the *discipline* it fires. Scheduling and execution stay separated.

**Research-grounded.** Built from three deep sweeps of the loop-engineering canon, distilled in `references/loop-canon.md` with attribution: Geoffrey Huntley's Ralph lineage (fresh-context loops, disposable plans, signs), Pete Steinberger's loop engineering (blast radius, silence contract, taste-in-the-loop), Boris Cherny + Anthropic harness doctrine (verification 2–3×'s quality, writer≠checker, evidence gates, STEER/kill files), HumanLayer 12-factor control flow (irreversible actions break the loop to a human), and the fleet-scale implementations (Gas Town, snarktank/ralph, iannuttall/ralph, vercel-labs/ralph-loop-agent). The canon doc also records where the lineages disagree and which side this family takes.

**Also includes** `references/loop-native-skills.md` — authoring guidance for skill-creator/plugin-creator: how to write skills that loops can call (machine-checkable outcomes, idempotency, evidence-shaped returns, side-effect declarations, eval-driven skill development).

## Changes

- `free-skills/loop-designer/` — SKILL.md + 6 references (archetypes, charter template, state schema, loop doctor, loop-native skills, loop canon)
- `free-skills/loop-runner/` — SKILL.md
- `free-skills/loop-orchestrator/` — SKILL.md
- `docs/CATALOG.md` — regenerated (107 → 110 skills)

## Test plan

- [x] `python3 scripts/validate_skills.py` — 110 skills spec-compliant, zero new warnings
- [x] `python3 scripts/generate_catalog.py` — catalog in sync
- [x] `python3 scripts/check_links.py` — no broken links across 251 markdown files
- [x] All three SKILL.md bodies ≤139 lines (well under the 500 cap); depth in references, one level deep
- [ ] Field test: design one real loop with `loop-designer` and run 3 iterations via `loop-runner` (suggested first target: the `.loop/business-os-*` fleet — this contract is compatible with its loop-doctor/verifier concepts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG9NZ8jX4J56a4MQo8mC4w

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG9NZ8jX4J56a4MQo8mC4w)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the skills catalog to 110 skills and added a new “Other” section for loop-related skills.
  * Added new guidance for designing, orchestrating, and running durable agent loops.
  * Introduced documentation for loop templates, archetypes, state tracking, verification checks, and runtime health rules.

* **Documentation**
  * Added several reference guides to help standardize loop-based skill usage and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->