### PR TITLE
Add design-asset-intake skill + design-assets registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 # 🧠 Claude Skills Library
 
-### 107 production-grade Agent Skills for Claude Code, Claude.ai & every major agentic runtime
+### 108 production-grade Agent Skills for Claude Code, Claude.ai & every major agentic runtime
 
 > Turn your AI agent into a domain expert. Each skill is a self-contained, spec-compliant
 > `SKILL.md` — engineered with real frameworks, current best practices, and opinionated guidance,
 > not 500 words of filler. Free. MIT-licensed. Installable in one command.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Skills](https://img.shields.io/badge/skills-107-blue.svg)](docs/CATALOG.md)
+[![Skills](https://img.shields.io/badge/skills-108-blue.svg)](docs/CATALOG.md)
 [![Frontmatter validated](https://img.shields.io/badge/frontmatter-validated-success.svg)](scripts/validate_skills.py)
 [![Runtimes](https://img.shields.io/badge/runtimes-6-blueviolet.svg)](#-works-with-every-runtime)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
@@ -78,14 +78,14 @@ Every skill here:
 - ✅ Is **progressive-disclosure friendly**: a tight description for routing, deep guidance loaded only on use.
 - ✅ Carries a **trigger-rich description** so the right skill activates from a library of 100+.
 
-**107 skills** across AI agents, MCP & SDKs, frontend, Oracle/cloud, content & creative production,
+**108 skills** across AI agents, MCP & SDKs, frontend, Oracle/cloud, content & creative production,
 engineering workflow, and personal performance. **All free. MIT-licensed.**
 
 ---
 
 ## ⭐ Featured skills
 
-A small taste — see the **[full catalog](docs/CATALOG.md)** for all 107.
+A small taste — see the **[full catalog](docs/CATALOG.md)** for all 108.
 
 | Skill | Why you'd reach for it | Category |
 |---|---|---|
@@ -186,7 +186,7 @@ A single zero-dependency validator enforces the standard across every `SKILL.md`
 
 ```bash
 python3 scripts/validate_skills.py
-# OK: 107 skill file(s) are spec-compliant.
+# OK: 108 skill file(s) are spec-compliant.
 
 python3 scripts/generate_catalog.py          # regenerate docs/CATALOG.md
 python3 scripts/generate_catalog.py --check   # CI-friendly drift check
@@ -208,7 +208,7 @@ GitHub Pages (Settings → Pages → *Deploy from branch* → `main` / `/docs`).
 
 ## ❓ FAQ
 
-**Does loading 107 skills bloat my context?**
+**Does loading 108 skills bloat my context?**
 No. Only each skill's `name` + `description` is preloaded for routing; the full body loads **only when
 a skill triggers**, and `references/` load only when read. That's the whole point of progressive disclosure.
 

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -1,5 +1,5 @@
 # 📚 Skills Catalog
-The complete index of all **107 skills** in this library. Every skill ships as a self-contained `SKILL.md` with spec-compliant frontmatter (`name`, `description`) and works across Claude Code, Claude.ai, and other agentic runtimes (see [`runtimes/`](../runtimes/)).
+The complete index of all **108 skills** in this library. Every skill ships as a self-contained `SKILL.md` with spec-compliant frontmatter (`name`, `description`) and works across Claude Code, Claude.ai, and other agentic runtimes (see [`runtimes/`](../runtimes/)).
 
 > This file is generated. After adding or renaming a skill, run `python3 scripts/generate_catalog.py` to regenerate it, then `python3 scripts/validate_skills.py` to verify compliance.
 
@@ -58,13 +58,14 @@ _8 skills_
 | [`si`](../free-skills/si/SKILL.md) | Superintelligence router — composes /superintelligence reasoning with swarm execution only when verb intent demands it. Defaults to reasoning-only to prevent runaway swarm cost.... |
 
 ## Web, Frontend & Animation
-_14 skills_
+_15 skills_
 
 | Skill | Description |
 |---|---|
 | [`animejs`](../free-skills/animejs/SKILL.md) | Anime.js adapter patterns for HyperFrames. Use when writing Anime.js animations or timelines inside HyperFrames compositions, registering animations on window.__hfAnime, making... |
 | [`css-animations`](../free-skills/css-animations/SKILL.md) | CSS animation adapter patterns for HyperFrames. Use when authoring CSS keyframes, animation-delay based timing, animation-fill-mode, animation-play-state, or CSS-only motion tha... |
 | [`defuddle`](../free-skills/defuddle/SKILL.md) | Extract clean markdown content from web pages using Defuddle CLI, removing clutter and navigation to save tokens. Use instead of WebFetch when the user provides a URL to read or... |
+| [`design-asset-intake`](../free-skills/design-asset-intake/SKILL.md) | Triage an external GitHub design/UI/motion/shader library before wiring it into any site's design system. Use when someone shares a "free design asset library" repo/link (social... |
 | [`framer-expert`](../free-skills/framer-expert/SKILL.md) | Expert Framer design and development — interactive prototypes, production sites, Framer Motion, CMS integration, and the Framer MCP server. Use when building or styling Framer s... |
 | [`gsap`](../free-skills/gsap/SKILL.md) | GSAP animation reference for HyperFrames. Covers gsap.to(), from(), fromTo(), easing, stagger, defaults, timelines (gsap.timeline(), position parameter, labels, nesting, playbac... |
 | [`lottie`](../free-skills/lottie/SKILL.md) | Lottie and dotLottie adapter patterns for HyperFrames. Use when embedding lottie-web JSON animations, .lottie files, @lottiefiles/dotlottie-web players, registering instances on... |

--- a/free-skills/design-asset-intake/SKILL.md
+++ b/free-skills/design-asset-intake/SKILL.md
@@ -30,8 +30,10 @@ Read its README/package.json first — don't guess from the marketing post.
 2. **vendor-copy** — no npm package exists, but the source is small, self-contained, and
    meant to be copied (vanilla JS/CSS files, a single component file, "no build step" in
    the README). Copy the actual source files into the target design-system package under
-   `src/primitives/<name>/`, wrapped in whatever component API the design system expects.
-   Never leave vendored code un-wrapped or inconsistent with the rest of the primitives.
+   its own primitives convention (e.g. `src/primitives/<name>/` in `@arcanea/design-system`,
+   `components/ui/primitives/<name>/` in FrankX — check the target repo's own layout rather
+   than assuming), wrapped in whatever component API the design system expects. Never leave
+   vendored code un-wrapped or inconsistent with the rest of the primitives.
 3. **reference-study** — the repo is a demo app, a playground, or otherwise not meant to
    be installed or copied wholesale (e.g. a Next.js showcase for a shader technique). Do
    **not** vendor the whole app. Extract the specific technique (the shader, the easing
@@ -86,8 +88,14 @@ glass-card recipe), that's a call for the human, not something this skill decide
 ## Distributing a new primitive to other sites
 
 Once a primitive is built and gated in one design system, don't hand-recreate it in
-every other repo. Copy the skill/primitive folder across using the existing sync
-mechanism (`starlight-agent-skills/scripts/port-skill.mjs <domain/skill> --target=<repo>`
-for skills; a plain folder copy plus a design-system export for code primitives), and
-add the target repo to the registry entry's `target_design_system` list so the registry
-stays the accurate cross-repo record.
+every other repo. For skills, the sibling `starlight-agent-skills` repo (a different
+repo from this one) has a sync script, `scripts/port-skill.mjs <domain/skill>
+--target=<repo>` — but it assumes that repo's own nested `domain/skill` + `manifest.json`
+shape, which doesn't match this repo's flat `free-skills/<name>/SKILL.md` layout, so it
+won't run as-is against a skill copied from here. For a flat skill like this one, a plain
+folder copy into the target repo's own skill convention (checking whether it's
+`.claude/skills/` or something else — some repos gitignore `.claude/skills/*/` and keep
+the committed copy elsewhere, e.g. `.arcanea/skills/`) is the practical fallback. For code
+primitives, copy the file plus add its export to the target design-system's index. Either
+way, add the target repo to the registry entry's `target_design_system` list so the
+registry stays the accurate cross-repo record.

--- a/free-skills/design-asset-intake/SKILL.md
+++ b/free-skills/design-asset-intake/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: design-asset-intake
+description: Triage an external GitHub design/UI/motion/shader library before wiring it into any site's design system. Use when someone shares a "free design asset library" repo/link (social media, a README, a tweet), when deciding whether to npm-install, vendor-copy, or just study a repo, or when logging a new entry in registries/design-assets.json.
+---
+
+# Design Asset Intake
+
+Design-asset repos show up constantly (social media roundups, "awesome-X" lists, a
+friend's link). Most get bookmarked and forgotten. This skill makes absorbing one into
+a real site a repeatable, five-minute triage instead of a one-off copy-paste.
+
+## When to use this
+
+- Someone shares a GitHub repo billed as a design/UI/animation/shader "asset library."
+- You're deciding whether a repo should become an npm dependency, vendored source, or
+  just a technique to study.
+- You're about to add a new entry to `registries/design-assets.json`.
+- You're wiring a new primitive into a site's design system (e.g. `@arcanea/design-system`
+  or a FrankX `lib/design-system.ts` consumer) and need to know where it came from.
+
+## The triage
+
+Before touching any site repo, classify the source repo into exactly one of three types.
+Read its README/package.json first — don't guess from the marketing post.
+
+1. **npm-dependency** — it publishes a real package to npm (check the README's install
+   snippet, or `npm view <name>`). Just add it to the consuming app's `package.json` like
+   any other dependency. Note its peer deps (e.g. a three.js-based library usually wants
+   `@react-three/fiber` + `three` already present).
+2. **vendor-copy** — no npm package exists, but the source is small, self-contained, and
+   meant to be copied (vanilla JS/CSS files, a single component file, "no build step" in
+   the README). Copy the actual source files into the target design-system package under
+   `src/primitives/<name>/`, wrapped in whatever component API the design system expects.
+   Never leave vendored code un-wrapped or inconsistent with the rest of the primitives.
+3. **reference-study** — the repo is a demo app, a playground, or otherwise not meant to
+   be installed or copied wholesale (e.g. a Next.js showcase for a shader technique). Do
+   **not** vendor the whole app. Extract the specific technique (the shader, the easing
+   curve, the layout trick) and hand-author ONE new primitive inspired by it, the same way
+   existing hand-ported primitives (e.g. Magic UI ports in `@arcanea/design-system`) were
+   built. Log it as reference-only; building the derived primitive can be a separate,
+   later step.
+
+When unsure between vendor-copy and reference-study, the test is: "would I ever run
+`npm install` or `cp` this repo's actual source into my repo?" If yes and the surface
+area is small, vendor-copy. If the repo is really an app/demo, reference-study.
+
+## Log the entry
+
+Every adopted (or explicitly reference-logged) library gets one entry in
+[`registries/design-assets.json`](../../registries/design-assets.json) at the repo root:
+
+```json
+{
+  "name": "<library name>",
+  "source_url": "<github url>",
+  "integration_type": "npm-dependency | vendor-copy | reference-study",
+  "package": "<npm package name, or null>",
+  "requires": ["<peer deps>", "..."],
+  "target_design_system": ["<consuming repo/package path>"],
+  "added_date": "<YYYY-MM-DD>",
+  "brand_fit_notes": "<why it fits, how it's wrapped, any restraint rule it must obey>"
+}
+```
+
+This is the single place to check before re-triaging something that's already been
+absorbed, and the place a future agent (or Frank) looks first when asked "have we already
+looked at X?"
+
+## Route through the brand gate
+
+A registry entry is not a ship decision. Every new primitive built from an intake still
+has to pass the target site's existing brand gate before it's called done:
+
+- FrankX (`frankx.ai-vercel-website`/`FrankX`): `taste.md`'s 8-step polish pass, gated by
+  the `visual-brand-guidelines` agent.
+- Arcanea (`arcanea-ai-app`): `TASTE.md`'s 7-gate bar, routed through the
+  `design-architect` -> `design-generator` -> `design-motion` -> `design-verifier` agent
+  pipeline (that pipeline already exists specifically to intake external patterns and
+  refactor them into brand tokens — use it, don't bypass it).
+
+Heavier effects (WebGL, shader, 3D) are opt-in for a single deliberate hero moment per
+page — they supplement the existing default look, they don't quietly become the new
+default. If a change would replace an existing locked visual signature (e.g. a fixed
+glass-card recipe), that's a call for the human, not something this skill decides.
+
+## Distributing a new primitive to other sites
+
+Once a primitive is built and gated in one design system, don't hand-recreate it in
+every other repo. Copy the skill/primitive folder across using the existing sync
+mechanism (`starlight-agent-skills/scripts/port-skill.mjs <domain/skill> --target=<repo>`
+for skills; a plain folder copy plus a design-system export for code primitives), and
+add the target repo to the registry entry's `target_design_system` list so the registry
+stays the accurate cross-repo record.

--- a/registries/design-assets.json
+++ b/registries/design-assets.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://frankxai.github.io/claude-skills-library/schemas/design-assets.schema.json",
   "description": "Source of truth for external GitHub design/UI/motion libraries adopted across FrankX and Arcanea sites. Triage every new find here before touching any site repo. See free-skills/design-asset-intake/SKILL.md for the process this registry supports.",
   "assets": [
     {
@@ -26,10 +25,10 @@
       "source_url": "https://github.com/dashersw/liquid-glass-js",
       "integration_type": "vendor-copy",
       "package": null,
-      "requires": ["html2canvas (hard runtime dependency — container.js calls it unconditionally in capturePageSnapshot())"],
+      "requires": ["html2canvas"],
       "target_design_system": ["arcanea-ai-app/packages/design-system"],
       "added_date": "2026-07-03",
-      "brand_fit_notes": "Vanilla JS, no npm package exists — vendored verbatim (container.js/button.js/glass.css/LICENSE) into packages/design-system/src/primitives/liquid-glass/vendor/, plus a bridge.js adapter (authored here) that exposes the classic-script Container/Button classes as window.__LiquidGlassJS for the LiquidGlassButton React wrapper to consume. Static assets copied to apps/web/public/vendor/liquid-glass-js/ for serving (design-system's tsc build doesn't copy non-TS assets — flagged as future build-step work). Ships OPT-IN alongside the existing CSS glass-card recipe (bg-white/[0.03] border-white/[0.06] backdrop-blur-sm), which stays the default per taste.md/TASTE.md. KNOWN LIMITATION: upstream registers a permanent window scroll listener with no destroy()/teardown API — mount once for the page's lifetime, don't remount."
+      "brand_fit_notes": "Vanilla JS, no npm package exists — vendored verbatim (container.js/button.js/glass.css/LICENSE) into packages/design-system/src/primitives/liquid-glass/vendor/, plus a bridge.js adapter (authored here) that exposes the classic-script Container/Button classes as window.__LiquidGlassJS for the LiquidGlassButton React wrapper to consume. html2canvas is a hard runtime dependency, not optional — container.js calls it unconditionally in capturePageSnapshot(). Static assets copied to apps/web/public/vendor/liquid-glass-js/ for serving (design-system's tsc build doesn't copy non-TS assets — flagged as future build-step work). Ships OPT-IN alongside the existing CSS glass-card recipe (bg-white/[0.03] border-white/[0.06] backdrop-blur-sm), which stays the default per taste.md/TASTE.md. KNOWN LIMITATION: upstream registers a permanent window scroll listener with no destroy()/teardown API — mount once for the page's lifetime, don't remount."
     },
     {
       "name": "liquid-logo (Paper Shaders)",

--- a/registries/design-assets.json
+++ b/registries/design-assets.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://frankxai.github.io/claude-skills-library/schemas/design-assets.schema.json",
+  "description": "Source of truth for external GitHub design/UI/motion libraries adopted across FrankX and Arcanea sites. Triage every new find here before touching any site repo. See free-skills/design-asset-intake/SKILL.md for the process this registry supports.",
+  "assets": [
+    {
+      "name": "react-three-fiber",
+      "source_url": "https://github.com/pmndrs/react-three-fiber",
+      "integration_type": "npm-dependency",
+      "package": "@react-three/fiber",
+      "target_design_system": ["frankx.ai-vercel-website", "arcanea-ai-app/packages/design-system"],
+      "added_date": "2026-07-03",
+      "brand_fit_notes": "Canonical React renderer for three.js. Already installed in FrankX (frankx.ai-vercel-website/FrankX). Missing in arcanea-ai-app — needed as the base for the ShaderGradient primitive below."
+    },
+    {
+      "name": "ShaderGradient",
+      "source_url": "https://github.com/ruucm/shadergradient",
+      "integration_type": "npm-dependency",
+      "package": "@shadergradient/react",
+      "requires": ["@react-three/fiber", "three", "three-stdlib", "camera-controls"],
+      "target_design_system": ["arcanea-ai-app/packages/design-system"],
+      "added_date": "2026-07-03",
+      "brand_fit_notes": "3D animated gradient background. Wrap in a brand-token-driven primitive (feed cosmic teal/blue/gold into color1/color2/color3 props, don't ship its default palette). One hero moment per page — route through design-motion's restraint rule. Route through design-architect -> design-generator -> design-motion -> design-verifier before shipping. Skipped @shadergradient/ui (published at 0.0.0, editor-controls package, not needed for a static/parameterized background)."
+    },
+    {
+      "name": "liquid-glass-js",
+      "source_url": "https://github.com/dashersw/liquid-glass-js",
+      "integration_type": "vendor-copy",
+      "package": null,
+      "requires": ["html2canvas (hard runtime dependency — container.js calls it unconditionally in capturePageSnapshot())"],
+      "target_design_system": ["arcanea-ai-app/packages/design-system"],
+      "added_date": "2026-07-03",
+      "brand_fit_notes": "Vanilla JS, no npm package exists — vendored verbatim (container.js/button.js/glass.css/LICENSE) into packages/design-system/src/primitives/liquid-glass/vendor/, plus a bridge.js adapter (authored here) that exposes the classic-script Container/Button classes as window.__LiquidGlassJS for the LiquidGlassButton React wrapper to consume. Static assets copied to apps/web/public/vendor/liquid-glass-js/ for serving (design-system's tsc build doesn't copy non-TS assets — flagged as future build-step work). Ships OPT-IN alongside the existing CSS glass-card recipe (bg-white/[0.03] border-white/[0.06] backdrop-blur-sm), which stays the default per taste.md/TASTE.md. KNOWN LIMITATION: upstream registers a permanent window scroll listener with no destroy()/teardown API — mount once for the page's lifetime, don't remount."
+    },
+    {
+      "name": "liquid-logo (Paper Shaders)",
+      "source_url": "https://github.com/paper-design/liquid-logo",
+      "integration_type": "reference-study",
+      "package": null,
+      "target_design_system": ["arcanea-ai-app/packages/design-system"],
+      "added_date": "2026-07-03",
+      "brand_fit_notes": "This is a full Next.js demo app for Paper Shaders' liquid-metal effect, not an installable library. Do NOT vendor the repo. Study the GLSL shader technique and, if wanted, hand-port a single derived primitive (candidate: liquid-metal-text.tsx) the same way Magic UI primitives were already hand-ported into @arcanea/design-system. Logged as future work, not yet built."
+    }
+  ]
+}

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -31,7 +31,7 @@ CATEGORIES = [
     ("AI Agents & Orchestration", r"agentic|swarm|hive-mind|stream-chain|model-routing|reasoningbank|memory-prune|opus-extended|sparc|pair-programming|nextjs-agent-team"),
     ("AI Frameworks, MCP & SDKs", r"^mcp|mcp-|openai-agentkit|claude-sdk|langgraph|oracle-adk|oracle-agent-spec|partner-"),
     ("Oracle & Cloud", r"oracle|^oci|^si$|ai-architecture"),
-    ("Web, Frontend & Animation", r"nextjs|tailwind|^three$|framer|web-design|ui-ux|css-animations|animejs|gsap|lottie|waapi|defuddle"),
+    ("Web, Frontend & Animation", r"nextjs|tailwind|^three$|framer|web-design|ui-ux|css-animations|animejs|gsap|lottie|waapi|defuddle|design-asset"),
     ("Engineering Workflow & GitHub", r"github|performance-analysis|verification-quality|hooks-automation|worker-|skill-comply|template-skill"),
     ("Content, Writing & Brand", r"brand|book|newsletter|social-media|content-strategy|creator|prompt-hub|internal-comms"),
     ("Creative & Media Production", r"suno|higgsfield|hyperframes|website-to|remotion|starlight|arcanea|acos|cacos|video-production|algorithmic-art|canvas|theme-factory|slack-gif|artifacts-builder|creator-intelligence"),


### PR DESCRIPTION
## Summary

Frank asked where design approach/skills are managed across FrankX and Arcanea sites, and how to wire external "free design asset library" GitHub repos (ShaderGradient, liquid-glass-js, liquid-logo, react-three-fiber) in more systematically instead of one-off bookmarking. This adds the shared triage layer both consuming repos (`arcanea-ai-app`, `frankx.ai-vercel-website`) now use.

## Changes

- `registries/design-assets.json` — source of truth for adopted external design/UI/motion/shader libraries. Seeded with the 4 flagged repos, each correctly typed after actually fetching their READMEs: `react-three-fiber` and `ShaderGradient` = npm-dependency; `liquid-glass-js` = vendor-copy (no npm package exists); `liquid-logo` (Paper Shaders) = reference-study (it's a demo app, not an installable library — corrected from the initial assumption).
- `free-skills/design-asset-intake/SKILL.md` — triage skill: npm-dependency / vendor-copy / reference-study decision, where to log the registry entry, and the mandatory brand-gate step before anything ships.
- `docs/CATALOG.md` regenerated (108 skills), `scripts/generate_catalog.py` category regex extended to catch `design-asset-*` skills, `README.md` skill counts updated (107 → 108).

## Test plan

- [x] `python3 scripts/validate_skills.py` — 108 skill files spec-compliant, no new errors
- [x] `python3 scripts/check_links.py` — no broken internal links across 243 markdown files
- [x] `python3 -m json.tool registries/design-assets.json` — valid JSON

## Related

- Companion PRs: `arcanea-ai-app` (ShaderGradientBackground + LiquidGlassButton primitives), `frankx.ai-vercel-website` (skill distribution only)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SXFPviwqHpDgohhLCKkF51)_