### PR TITLE
Add film-excellence pack — the craft layer for narrative film work

### DIFF
--- a/packs/film-excellence/CREW.md
+++ b/packs/film-excellence/CREW.md
@@ -1,0 +1,128 @@
+# CREW — the agent team, and which model runs which chair
+
+> A film crew is small. The failure mode of agentic production is a forty-agent
+> org chart that produces committee output. Seven chairs and two gates.
+
+---
+
+## The chairs
+
+| # | Chair | Owns | Does **not** do | Volume |
+|---|---|---|---|---|
+| 1 | **Showrunner** | The turn, the spine, every cut decision | Generation, prompt-writing | Low, decisive |
+| 2 | **Canon Keeper** | Consistency with the world's locked canon | Story structure, taste calls | Low, blocking |
+| 3 | **Dramatist** | Beat sheet, scene order, where the turn lands | Dialogue lines, shot design | Medium |
+| 4 | **Voice-Smith** | Dialogue passes under `LANGUAGE.md` | Deciding which line ships | **Very high** |
+| 5 | **Shot Wright** | Script → shot list under the camera law | Executing generation | Medium → high |
+| 6 | **Wrangler** | Generation batches, character IDs, seeds, retries, the asset ledger | Any creative judgment | **Very high, mechanical** |
+| 7 | **Sound Designer** | Bed, foley, music map, the silence | Picture | Medium |
+
+Plus two **gates**. Gates are not crew — they refuse, they don't contribute:
+
+| Gate | Question | Authority |
+|---|---|---|
+| **Taste Gate** | "Does this land on anything in the refusal list?" | Blocks. Adversarial by design. Prompted to find the reason this is generic, not to praise. |
+| **Continuity Gate** | "Does this contradict the bible, the canon, or an earlier shot?" | Blocks. Checks faces, wardrobe, light direction, prop state, time of day. |
+
+**The Showrunner is a human.** Every chair drafts; the Showrunner picks. That
+distinction is the entire authorship claim of the project and it should not be
+delegated to save time — it is the only step that cannot be reconstructed later.
+
+---
+
+## Model routing
+
+The routing principle is **job shape, not job importance**:
+
+- **Judgment, structure, refusal, single-shot correctness** → strongest model.
+  These are low-volume, high-consequence, and a wrong answer is expensive.
+- **Variance generation with a human selector** → fastest capable model.
+  These are high-volume and a wrong answer costs one discarded candidate.
+- **Deterministic mechanical work** → mid-tier. No reasoning premium to pay.
+
+| Chair | Model | Why |
+|---|---|---|
+| Showrunner | Opus 5 (+ human) | Every decision is irreversible in the edit |
+| Canon Keeper | Opus 5 | Blocking authority; false negatives corrupt the world |
+| Dramatist | Opus 5 | Structure is the highest-leverage artifact in the film |
+| **Voice-Smith** | **Fable 5** | 8–12 line variants per beat, human picks one. Highest-volume creative-variance job in the pipeline |
+| Shot Wright | Opus 5 → **Fable 5** | Opus designs the shot grammar once; Fable expands each shot into prompt variants |
+| Wrangler | Sonnet 5 | API orchestration, retries, ledger writes. No judgment |
+| Sound Designer | Sonnet 5 → Opus 5 | Sonnet for the map, Opus for the one moment sound carries alone |
+| Taste Gate | Opus 5 | Adversarial refusal needs the strongest reader |
+| Continuity Gate | Sonnet 5 | Checklist comparison against the bible |
+
+### On Fable 5 specifically
+
+Fable 5 is routed to the two jobs whose shape is *many diverse candidates, one
+human selection*: dialogue variants and shot-prompt variants. That is a
+throughput-and-diversity problem, not a judgment problem, and it is where a fast
+model is worth more than a slow one — because the value comes from the *spread*
+of the candidate set and the human's pick, not from any single candidate being
+right.
+
+**Verify this before committing the pipeline to it.** Run the bake-off below in
+week 1 rather than trusting the routing table. Half a day of measurement beats a
+month of a wrong assumption, and this pack's own doctrine says not to take
+capability claims on faith.
+
+#### Bake-off protocol (~30 minutes, run once)
+
+1. Take one hard beat from the actual script — an exchange where a character
+   must refuse to answer.
+2. Give three models the identical context: the beat, both Word Ledgers, the ten
+   rules from `LANGUAGE.md`.
+3. Request twelve variants from each. Strip attribution.
+4. Score each variant blind on four binaries: *breaks meter · deflects ·
+   zero abstract nouns · has subtext.* Count 4/4s per model.
+5. Also score **spread** — how many of the twelve are meaningfully different
+   from each other, rather than twelve rewordings of one idea. For this job
+   spread matters more than peak.
+6. Route the chair to whichever model wins on `4/4 count × spread`, at the
+   lowest cost that wins. Record the result in the film's `BIBLE.md`.
+
+Re-run when a model version changes. Don't re-run per scene.
+
+---
+
+## Interaction rules
+
+Borrowed from the substrate's `VOICES.md` because the failure mode is identical —
+agents that agree with each other produce mush.
+
+- Order in a review: **Dramatist → Voice-Smith → Sound Designer → Taste Gate → Showrunner.**
+  The Taste Gate always speaks second-to-last, and the Showrunner last.
+- Each chair gets **five sentences** in reflection mode, **three** in decision mode.
+- A chair with nothing to add says so in one sentence. Fabricated notes are worse
+  than no notes.
+- **The Taste Gate may not be overruled by another chair** — only by the human
+  Showrunner, on the record, with the reason written into the film's bible. If
+  the gate is overruled more than twice in a production, the gate is
+  miscalibrated or the film is in trouble; either way, stop and look.
+- No chair may hold two roles on the same scene. The Voice-Smith does not get to
+  approve its own lines; that is what produces the confident average.
+
+---
+
+## Parallelism
+
+Shots are independent. Beats are not.
+
+- **Writing is serial.** Bible → beats → script → shot list. Fanning this out
+  produces four incompatible films. One chair at a time, in order.
+- **Generation is a pipeline, not a barrier.** Each shot runs
+  `prompt-variants → generate → taste-check → keep or retry` on its own clock.
+  Shot 14 can be in retry while shot 3 is still generating. Never wait for all
+  shots at one stage before starting the next — that costs you the difference
+  between the slowest single chain and the sum of the slowest per stage, which
+  on a 60-shot film is days.
+- **Sound runs parallel to picture from the beat sheet onward.** It does not
+  wait for a cut. This is the discipline that produces designed sound rather
+  than laid-on music, and it is the single biggest reason to start it early.
+- **Cap concurrency at what a human can review.** Sixty shots generating at once
+  and nobody watching is how a film becomes a bin of clips. Batch to what the
+  Showrunner can actually screen in a sitting — roughly 12.
+
+---
+
+Built on SIP.

--- a/packs/film-excellence/DOCTRINE.md
+++ b/packs/film-excellence/DOCTRINE.md
@@ -86,6 +86,16 @@ Minimum bar for anything shipped from this pack:
 - Music enters late and leaves before the end. If music is running under the
   final image, you didn't trust the image.
 
+**A definition, because it gets misread every time.** When this pack says
+*silence*, it means **speech-free** — nobody is talking. Room tone, foley, and
+the location bed keep running underneath. A genuinely signal-free track reads as
+a dropout, not as silence, and the 20% budget is never asking for one.
+
+If a film wants a truly signal-free moment, that is a different thing: name it
+**total silence**, put it in the sound map with a timecode, and spend it once.
+It is one of the loudest events available in the medium, which is exactly why it
+does not survive being used twice.
+
 ### Law 5 — Imperfection is a signature
 
 Model output trends toward clean, symmetric, well-lit, and unblemished, because

--- a/packs/film-excellence/DOCTRINE.md
+++ b/packs/film-excellence/DOCTRINE.md
@@ -175,6 +175,47 @@ person who made the thing is the worst available judge of it.
 
 ---
 
+## The derived-figure rule
+
+**A number that summarises a table must be recomputable from that table, or it
+must not be written down.**
+
+This is the failure mode that actually happened across both reference builds,
+repeatedly, in documents that were otherwise careful. Every instance had the
+same shape: a figure written as prose *about* the data rather than read *from*
+it. In order of discovery —
+
+| The claim | What it summarised | How it broke |
+|---|---|---|
+| speech-free total | the beat table | two beats omitted; 86s / 34.4% claimed against a real 102s / 40.8% |
+| runtime | beats + end card | card excluded from the total but not the beat table |
+| speech-free denominator | picture vs total | card excluded from one side of the ratio only |
+| indirect references to a character | the script | invented at bible stage as "thirty-one"; the script came in at four |
+| deflections in a rule-check | the script | "three times" in a row that also said one of the three was an inversion |
+| a hand-reveal timecode | the beat table | pinned to a second that had drifted two beats away |
+
+None of these were sloppiness in the usual sense. They were written accurately
+and then the thing underneath them moved. That is what a derived figure *does*.
+
+**So the rule has three parts:**
+
+1. **Store per-item, derive the total.** `beat_seconds: { 1: 22, 2: 18, … }` in
+   the design contract, and every percentage computed from it. A total with no
+   per-item data behind it has nothing keeping it honest.
+2. **Refer to beats, never timecodes** — outside the beat table itself, which is
+   the timing record and therefore may hold timecodes as its content. Beats are
+   stable under redrafting; the seconds inside them are not.
+3. **Sweep before the commit, not after.** Every one of these was caught by a
+   reader recomputing the arithmetic. Recompute it yourself first, at the moment
+   you change anything the figure depends on.
+
+The general form, worth stating because it outlives film: **prose totals drift
+and per-item data does not.** Any figure a human maintains by hand, in a
+document nobody recounts, is a defect with a delay on it — and precise figures
+are the most dangerous, because precision reads as evidence of care.
+
+---
+
 ## What this doctrine is not
 
 It is not a style. Two films built under it should not look alike — the two

--- a/packs/film-excellence/DOCTRINE.md
+++ b/packs/film-excellence/DOCTRINE.md
@@ -87,14 +87,22 @@ Minimum bar for anything shipped from this pack:
   final image, you didn't trust the image.
 
 **A definition, because it gets misread every time.** When this pack says
-*silence*, it means **speech-free** — nobody is talking. Room tone, foley, and
-the location bed keep running underneath. A genuinely signal-free track reads as
-a dropout, not as silence, and the 20% budget is never asking for one.
+*silence*, it means **speech-free** — nobody is talking. It says nothing about
+what the bed is doing. Usually room tone, foley, and the location bed keep
+running underneath, and the 20% budget is never asking for a signal-free track,
+because that reads as a dropout rather than as silence.
 
-If a film wants a truly signal-free moment, that is a different thing: name it
-**total silence**, put it in the sound map with a timecode, and spend it once.
-It is one of the loudest events available in the medium, which is exactly why it
-does not survive being used twice.
+If a film wants a truly signal-free moment, that is **total silence** — name it,
+put it in the sound map with a timecode, and spend it once. It is one of the
+loudest events available in the medium, which is exactly why it does not survive
+being used twice.
+
+**Total silence is a *subset* of speech-free, not a sibling.** A signal-free
+moment obviously has no speech in it, so it counts toward the 20% budget and is
+described separately in the sound map. Treating the two as mutually exclusive
+produces a contract that contradicts itself — a beat listed under "the bed keeps
+running" that is also the beat where the bed stops. Say which beats have the bed
+running and which do not; do not try to sort the beat into one bucket.
 
 ### Law 5 — Imperfection is a signature
 

--- a/packs/film-excellence/DOCTRINE.md
+++ b/packs/film-excellence/DOCTRINE.md
@@ -1,0 +1,171 @@
+# DOCTRINE — how we make films that don't read as AI films
+
+> The constitution of the pack. Everything else in `film-excellence` implements this.
+> Where this file and a skill disagree, this file wins. Where a repo's own
+> `film-design.md` / `film-taste.md` and this file disagree, the repo wins.
+
+---
+
+## The premise
+
+Every entrant has the same models. Model access is not a differentiator and has
+not been one since roughly the middle of 2025. Compute is table stakes; a jury
+sees the same photoreal 8-second clip from four thousand people.
+
+What is still scarce, in order of scarcity:
+
+1. **A character someone believes in inside twenty seconds.**
+2. **Sound that was designed rather than dropped on.**
+3. **A formal rule the film obeys** — a self-imposed constraint that a viewer
+   feels without being able to name.
+4. **Dialogue that doesn't sound written by a language model.**
+5. **Restraint** — the willingness to not use a capability you have.
+
+Every one of those is a writing and taste problem, not a generation problem.
+That is where our budget goes. This pack exists to force that allocation.
+
+---
+
+## The five laws
+
+### Law 1 — Constraint before capability
+
+Before any generation, the film declares a **formal rule it will not break**:
+one camera law, one color law, one sound law. The rule must be simple enough to
+state in a sentence and strict enough to hurt at least twice during production.
+
+Examples of real rules (pick your own, don't reuse these):
+- The camera never rises above standing eye-height until the final shot.
+- Exactly one saturated color exists in the film, and it appears for four seconds.
+- No cut happens on a movement; every cut lands on stillness.
+- The film contains no visible screen, interface, or readable text.
+
+A film with no declared rule is a reel, not a film. Juries can tell the
+difference and so can audiences, even when they can't articulate why.
+
+**Why this works:** a model's default output is the statistical center of its
+training distribution. A constraint is the cheapest possible way to move off
+that center in a direction you chose, rather than a direction noise chose. It
+converts "the model made this" into "someone decided this."
+
+### Law 2 — The turn is the film
+
+A 3–5 minute film gets **one** reversal. Not three. One thing the audience
+believed at 0:30 must be false at 3:00, and the falseness must recontextualize
+everything before it rather than merely adding information.
+
+Write the turn first. Write the last shot second. Everything between them is
+service.
+
+If you cannot state the turn as *"they think X; actually Y"* in one line, there
+is no film yet and no amount of production value will install one.
+
+### Law 3 — Earn the face
+
+The audience must want something for a specific person before the world gets
+explained. Not sympathy — *want*. They must want them to get the thing, open the
+door, say the sentence.
+
+Practical test: cut your first sixty seconds and ask a stranger "what does she
+want?" If they answer with a plot fact ("to escape") rather than a human want
+("to be believed"), the opening is world-building wearing a character costume.
+
+World-building is the most seductive failure mode available to anyone with a
+canon this large. Canon is a resource for the *background* of shots. It is not
+the subject.
+
+### Law 4 — Sound is half the film and gets half the discipline
+
+The single largest quality gap in the AI film field is audio. Most entries are
+picture with music laid over. That is a slideshow with a soundtrack.
+
+Minimum bar for anything shipped from this pack:
+- A **continuous spatial bed** per location, running under everything.
+- **Foley on the three most important physical actions** in the film.
+- At least one moment where the sound design carries a beat the picture does not.
+- Music enters late and leaves before the end. If music is running under the
+  final image, you didn't trust the image.
+
+### Law 5 — Imperfection is a signature
+
+Model output trends toward clean, symmetric, well-lit, and unblemished, because
+that is what "good" looks like in aggregate. Aggregate-good reads as nobody.
+
+Deliberately introduce, and keep:
+- At least three shots where something goes physically wrong in frame — dust
+  obscures the subject, a flare wrecks the composition, focus misses and
+  recovers.
+- One asymmetry on every principal face: a scar, a crooked tooth, chapped lips,
+  a lazy eye, sweat, a badly healed break. Written into the character sheet so
+  it persists.
+- **Hands, deliberately, three times.** Close, doing a real task. The field
+  avoids hands because models used to fail at them. Shooting hands on purpose
+  reads as confidence to anyone who knows the medium — and everyone on a jury
+  knows the medium.
+
+---
+
+## The refusals
+
+These are not stylistic preferences. They are the statistical center of the
+field, and landing on any of them costs you the "who made this" question.
+
+**Openers we do not shoot:** drone over a city at dusk · an eye opening in
+extreme close-up · rain on neon · a hand reaching toward light · a hooded
+figure walking away from camera · dust motes in a cathedral shaft · a slow
+turn-to-camera in slow motion · a title card over a black screen with a low
+drone.
+
+**Grammar we do not use:** the 360° orbit · the hero walking toward camera not
+looking at the explosion · the infinite push-in used on every shot because the
+model does it well · unmotivated slow motion · a dolly zoom deployed for any
+reason other than the one Hitchcock had.
+
+**Palettes we do not grade to:** teal-and-orange · the purple-cyan gradient that
+every image model reaches for when asked for "cinematic" · bloom on everything ·
+pure black crush with no shadow detail.
+
+**Sound we do not use:** the braaam · riser → silence → drop · generic epic
+choir · "cinematic whoosh" as a transition · a needle-drop that tells the
+audience how to feel thirty seconds before they'd have felt it.
+
+**Faces we do not cast:** the beautiful blank. Symmetric, unlined, ageless,
+expressionless. It is the model's default human and it is nobody.
+
+**Structures we do not write:** the voiceover that explains the world · the
+mentor who arrives to deliver rules · the montage of training · the final line
+that states the theme · anything that could be described as "a lone survivor
+in a ruined world reflects on what humanity lost."
+
+---
+
+## The evidence rule
+
+Nothing ships as "done" on assertion. `film-release-gate` refuses to certify a
+cut without:
+
+- the declared formal rule, and the two places it hurt
+- the turn, stated in one line
+- a sound map showing bed / foley / music-in / music-out
+- the three hand shots, timecoded
+- a language pass logged against `LANGUAGE.md`
+- a full-film watch at 1× with no scrubbing, by someone who did not make it
+
+Self-assigned scores are not evidence. "It looks great" is not evidence. This
+mirrors the `web-release-gate` contract and works for the same reason: the
+person who made the thing is the worst available judge of it.
+
+---
+
+## What this doctrine is not
+
+It is not a style. Two films built under it should not look alike — the two
+reference builds (`holdfast`, `what-he-left-running`) deliberately share no
+palette, no lens language, no tempo, and no genre.
+
+It is a set of forcing functions against the specific way generative tools fail:
+by producing the average of everything, beautifully.
+
+---
+
+Built on SIP.

--- a/packs/film-excellence/LANGUAGE.md
+++ b/packs/film-excellence/LANGUAGE.md
@@ -1,0 +1,186 @@
+# THE SPOKEN LAW — dialogue that does not read as machine-written
+
+> The hardest and most valuable layer in the pack. Picture quality has converged
+> across the field; language has not. Almost every AI short still gives itself
+> away in the first spoken line.
+
+---
+
+## Why AI dialogue is identifiable
+
+Not because it is bad. Because it is *regular*. Eleven tells, in rough order of
+how fast they give you away:
+
+| # | Tell | What it sounds like |
+|---|---|---|
+| 1 | **Theme stated aloud** | "Maybe the real power was inside us all along." |
+| 2 | **Abstract nouns** | destiny, purpose, balance, truth, legacy, journey |
+| 3 | **Symmetric exchange** | Every question gets a complete, on-topic answer |
+| 4 | **Metrical evenness** | Every line lands within a few words of the last |
+| 5 | **Emotional self-report** | "I'm afraid." "I feel lost." |
+| 6 | **Explaining the known** | Two insiders explaining their own world to each other |
+| 7 | **No interruption** | Nobody is ever cut off mid-word |
+| 8 | **Name-calling** | "Sarah, you have to understand—" as an ID badge |
+| 9 | **Zero subtext** | The line means exactly and only what it says |
+| 10 | **Complete sentences** | Nobody trails, fragments, or restarts |
+| 11 | **The closing aphorism** | The last line is the moral, polished |
+
+A model produces these because it is trained to be maximally comprehensible.
+Real speech is not optimized for comprehension. It is optimized for the speaker
+getting what they want while giving away as little as possible.
+
+---
+
+## The ten rules
+
+Each is binary and checkable. `film-release-gate` runs them as a pass.
+
+**1. Nobody names the theme.**
+If a line could serve as the film's logline, cut it. No exceptions, no "but it's
+earned." It is never earned.
+
+**2. No abstract nouns in dialogue.**
+Banned outright: *destiny, purpose, balance, truth, power, legacy, journey,
+chosen, fate, darkness, light, hope, meaning, connection.* Characters speak in
+concrete nouns and physical verbs. Instead of "you're afraid," a character says
+"your hands are shaking." Instead of "we've lost our way," "we passed that rock
+already."
+
+**3. Answer the wrong question.**
+In every exchange of three or more lines, at least one reply must answer
+something that was not asked, or refuse to answer at all. This single rule does
+more than the other nine combined. Real conversation is two people talking past
+each other with occasional collisions.
+
+**4. Break the meter.**
+No two consecutive lines within four words of each other in length. Force
+asymmetry: a nine-word line, then a two-word line, then a twenty-word line that
+runs out of air.
+
+**5. Every scene has a physical want.**
+Under the verbal negotiation, someone wants a thing in the room — the cup, the
+chair, the door open, to be touched, to leave. Blocking plays the physical want.
+Dialogue plays the verbal one. They should be in tension.
+
+**6. The world is old to them.**
+Nobody explains anything they've known since childhood. Terminology is used the
+way a nurse says "sats" — flat, fast, unglossed. If the audience needs a term,
+they get it once, from behavior, in the background, and never again.
+*Corollary: the more canon you have, the less of it belongs in the mouth.*
+
+**7. Interruption budget.**
+At least one line per scene is cut off mid-word — by another character, by an
+event, or by the speaker abandoning it. Write the fragment; don't write the
+whole line and trim in the edit.
+
+**8. Twenty percent silence.**
+At least a fifth of runtime has no speech in it. In a four-minute film, that's
+forty-eight seconds where the film has to work on picture and sound alone. If it
+can't, the script is leaning on dialogue it hasn't earned.
+
+**9. Names cost something.**
+A character says another's name only when it does work — as a warning, a plea,
+a claim of intimacy, an accusation. Never as identification for the audience.
+
+**10. The last line is mundane.**
+The final spoken line should be small, practical, and apparently about
+something else, landing on the largest moment in the film. "You'll want a coat."
+"It's the third one down." Never the summary.
+
+---
+
+## Positive technique — build a mouth, not a voice
+
+Rules prevent slop. These produce *character*.
+
+### The Word Ledger
+
+Every principal gets, written into their dossier before a line is drafted:
+
+- **Five words only they say.** Drawn from their trade, their region, their
+  damage. A stonemason says *bed, course, spall, plumb, green* (green stone =
+  freshly quarried, still wet). Nobody else in the film may use them.
+- **Five words they cannot say.** Usually the emotional register they avoid.
+  A character who cannot say *sorry, scared, stay, please, mine* will spend the
+  whole film going around those words, and the audience will feel the shape of
+  the hole.
+- **One grammatical tic.** Not an accent — a *structure*. Answers questions with
+  questions. Never uses contractions. Starts sentences twice. Ends declaratives
+  on an upward inflection. Uses the passive voice when lying.
+
+The ledger is the single highest-leverage artifact in the writing phase. Two
+characters with different ledgers cannot sound alike even if the same model
+writes both.
+
+### Idiolect over dialect
+
+Never write phonetic accent (*"Oi don' rightly know"*). Write **syntax**. Region
+and class live in word order and sentence length, not spelling. Phonetic accent
+is the mark of an amateur in every medium.
+
+### Load the object
+
+The strongest line in a scene is usually about an object. Grief goes into "the
+kettle's broken." Love goes into "I kept your side of the bed made." Route the
+emotion through the nearest physical thing in the room and let the actor's face
+carry the rest.
+
+---
+
+## Voiceover
+
+**Default: no voiceover.** It is the field's most-abused device precisely
+because it's the easiest thing to generate.
+
+VO is permitted only if it passes all three:
+1. It is **in scene** — someone is actually speaking, to someone, for a reason.
+2. It contains **information the speaker is wrong about.**
+3. Removing it would make the film *unclear*, not merely *less atmospheric.*
+
+If it's a disembodied gravelly reflection on what humanity lost, delete it and
+you have improved the film.
+
+---
+
+## The generation protocol
+
+How to actually get these lines out of a model.
+
+**Never ask for a scene.** Asking a model for "a scene between X and Y" returns
+the center of the distribution — regular, symmetric, thematic. Instead:
+
+1. **Write the want.** Each character's want in the scene, in one line, and what
+   they will not say.
+2. **Generate eight versions of the single hardest line**, with the Word Ledger
+   and the ten rules in context, and an explicit instruction that at least three
+   versions must refuse to answer the question.
+3. **The human picks.** Not the model. Picking is the authorship.
+4. **Pass 2: break the meter.** Feed the assembled scene back with one job —
+   vary line lengths, insert the interruption, remove one line entirely.
+5. **Pass 3: subtract.** Remove the three lines the scene can survive without.
+   There are always three. This pass is where the scene becomes good.
+
+This is a high-volume, high-variance job with a human selector — which is
+exactly what to route to a fast model (see `CREW.md`). Structural work — the
+turn, the scene order, what the film is about — is not, and stays on the
+strongest model available.
+
+---
+
+## Checklist (run before any scene is shot)
+
+- [ ] No line states the theme
+- [ ] Zero banned abstract nouns
+- [ ] At least one deflected or unanswered question per exchange
+- [ ] No two consecutive lines within four words of each other
+- [ ] Physical want identified and blocked
+- [ ] Nothing explained that both speakers already know
+- [ ] At least one interruption, written as a fragment
+- [ ] Silence ≥ 20% of scene runtime
+- [ ] Names used only when they cost something
+- [ ] Final line is mundane
+- [ ] Every principal's Word Ledger respected — no cross-contamination
+
+---
+
+Built on SIP.

--- a/packs/film-excellence/LANGUAGE.md
+++ b/packs/film-excellence/LANGUAGE.md
@@ -112,6 +112,48 @@ The ledger is the single highest-leverage artifact in the writing phase. Two
 characters with different ledgers cannot sound alike even if the same model
 writes both.
 
+#### Audit the ledger by grep, never by reading
+
+**A ledger checked by eye is not checked.** In the `holdfast` reference build
+the ledger audit was a paragraph of prose, written by the same person who wrote
+the lines, and it declared the ledger clean. It was not. Two defects, both found
+by an outside reviewer:
+
+- The stonemason said *"The file missed one"* — and *file* belonged exclusively
+  to the assessor. One word, four lines from a section asserting zero collisions.
+- **None of her five exclusive words were spoken at all.** Zero of five. They
+  appeared only in *action* lines — "thumbs the spall away" — which are the
+  writer's words, not the character's, and do not count. A ledger exercised
+  entirely in stage directions is decoration.
+
+The second is the more dangerous, because nothing looks wrong. The document is
+present, the words are on the page, and the film sounds fine — but the technique
+did no work, and the argument that ledgers are load-bearing goes with it.
+
+Extract every line by speaker and grep it against both lists. It takes one
+command and it is not optional:
+
+```bash
+# every word only she may say — expect ≥ 1 each, or justify the reservation
+for w in bed course spall green plumb; do
+  printf '%s: ' "$w"
+  awk '/^\*\*KESS\*\*/{getline; print}' SCRIPT.md | grep -iwc "$w"
+done
+# every word only he may say — expect 0 in her mouth
+for w in threshold variance log terminal file; do … done
+```
+
+**A reserved word is legitimate; an unused ledger is not.** In short forms, or
+in a series pilot where the ledger is a forward constraint, some words will not
+land in the film you submit. Say which and why. The line between reserving and
+failing is whether the ledger **binds at least one line you actually shot**.
+
+**When a ledger blocks a line, take the block.** Both times this happened in the
+reference builds, the constraint produced the better line: an assessor who
+cannot say *stay* ends the film on *"Move over"*, and a mason who cannot say
+*file* answers *"It missed one"* — refusing to dignify the record with its name.
+The block is the technique working, not the technique getting in the way.
+
 ### Idiolect over dialect
 
 Never write phonetic accent (*"Oi don' rightly know"*). Write **syntax**. Region
@@ -179,7 +221,11 @@ strongest model available.
 - [ ] Silence ≥ 20% of scene runtime
 - [ ] Names used only when they cost something
 - [ ] Final line is mundane
-- [ ] Every principal's Word Ledger respected — no cross-contamination
+- [ ] Every principal's Word Ledger respected — **verified by grep, not by
+      reading**: zero of another character's exclusive words in this
+      character's mouth, and at least one of their own actually spoken. Words
+      appearing only in action lines do not count; any reserved word is named
+      and justified.
 
 ---
 

--- a/packs/film-excellence/PIPELINE.md
+++ b/packs/film-excellence/PIPELINE.md
@@ -1,0 +1,151 @@
+# PIPELINE — from premise to delivered cut
+
+> Eight stages. Each has one owner, one artifact, and one gate. A stage does not
+> start until the previous artifact exists on disk.
+
+---
+
+## Stage map
+
+| # | Stage | Command | Owner | Artifact | Gate |
+|---|---|---|---|---|---|
+| 1 | Bible | `/film-bible` | Showrunner | `BIBLE.md` | Turn stated in one line |
+| 2 | Characters | `/film-cast` | Dramatist | `CHARACTERS.md` | Word Ledger complete for every principal |
+| 3 | Beats | `/film-beats` | Dramatist | `TREATMENT.md` | Turn is located at a timecode |
+| 4 | Script | `/film-script` | Voice-Smith | `SCRIPT.md` | `LANGUAGE.md` checklist passes |
+| 5 | Look & Sound | `/film-look` | Showrunner + Sound | `LOOK-AND-SOUND.md` | Formal rule declared; sound map exists |
+| 6 | Shot list | `/film-shotlist` | Shot Wright | `SHOTLIST.md` | Camera law holds on every row |
+| 7 | Generate | `/film-generate` | Wrangler | `assets/` + `LEDGER.jsonl` | Taste Gate per shot |
+| 8 | Cut | `/film-cut` | Showrunner | the film | `film-release-gate` |
+
+The order is not negotiable and the temptation to skip to stage 7 on day one is
+the reason most AI shorts look like a bin of clips with a title card.
+
+---
+
+## Stage detail
+
+### 1 — Bible
+
+The premise, the turn, the world's rules *as they affect this story only*, and
+the formal constraint. Two pages. If it runs to ten, the film is unfocused.
+
+Mandatory fields: logline · the turn (`they think X; actually Y`) · the last
+shot · the formal rule · what this film is **not** about.
+
+That last field does more work than it looks like. Writing "this is not about
+the war" prevents forty shots of the war.
+
+### 2 — Characters
+
+Per principal: want, wound, what they will not say, the physical asymmetry,
+and the **Word Ledger** (5 words only they say, 5 they cannot say, 1 grammatical
+tic — see `LANGUAGE.md`).
+
+Also per principal: a **locked visual description** in the exact phrasing that
+will be used for character-reference generation, so the same string produces the
+same person every time. Wardrobe, age, build, hair, the asymmetry, and one
+detail that never changes across the film. This string is copied verbatim; it is
+never paraphrased.
+
+### 3 — Beats
+
+Twelve to eighteen beats for a four-minute film. Each beat: who wants what, what
+blocks it, what changes. Timecode every beat — a beat sheet without durations is
+a wish list, and runtime discipline is where most shorts lose the jury.
+
+Locate the turn explicitly. In a 4:00 film it wants to land between 2:30 and
+3:10 — late enough to have been earned, early enough that the audience gets to
+live in the new understanding before the credits.
+
+### 4 — Script
+
+Run the generation protocol in `LANGUAGE.md` — want first, eight variants of the
+hardest line, human picks, break the meter, subtract three lines. Then the
+checklist.
+
+**Subtract-three is not optional.** It is where a competent scene becomes good,
+and it is the pass a model will never volunteer.
+
+### 5 — Look & Sound
+
+- **Look:** the formal camera rule, the palette law (including the forbidden
+  color, if the film has one), lens language, aspect, grain/texture plan, and
+  the three deliberate imperfections from Doctrine Law 5.
+- **Sound:** the bed per location, foley on the three key physical actions,
+  music in-point and out-point, and the location of the silence. Written *before*
+  a frame is generated so picture can be cut to serve it.
+
+### 6 — Shot list
+
+One row per shot. Required columns:
+
+```
+id · beat · duration · size · height · movement · subject · light ·
+prompt_seed · character_ids · sound_cue · rule_check
+```
+
+`rule_check` is a hard yes/no against the film's declared formal rule. Any `no`
+either changes or gets a written exception in the bible. Three exceptions and
+the rule wasn't real.
+
+Budget **1.4× the shots you think you need.** Coverage is what lets you cut
+around a shot that never comes out right, and in generative production some
+shots simply never come out right.
+
+### 7 — Generate
+
+Mechanical, high-volume, pipelined per shot.
+
+**Character consistency is the whole ballgame.** Create a character reference
+once per principal, get the character ID, and reuse that ID on every shot that
+person appears in. Never re-describe a character in a shot prompt hoping to land
+the same face — that is how a film ends up with four different protagonists.
+Consistency across an asset set is the capability that separates a film from a
+moodboard, and it is the main reason to use a platform that supports persistent
+character IDs rather than raw per-clip generation.
+
+Per shot, the loop is:
+```
+prompt variants (Fable) → generate → Taste Gate → keep | retry (max 3) | flag for the Showrunner
+```
+
+Log **every** generation to `LEDGER.jsonl`: shot id, model, prompt, seed,
+character ids, cost, verdict. Non-negotiable for three reasons — retry needs the
+seed, the festival may require a production breakdown, and a film you cannot
+reconstruct is a film you cannot defend.
+
+Batch to what a human can screen in one sitting (~12). Screen every batch before
+launching the next. A pipeline nobody is watching produces a large bin of
+average.
+
+### 8 — Cut
+
+Assemble to the **sound map**, not to the shot list. Picture serves the sound
+plan that was written in stage 5.
+
+Then `film-release-gate`. It refuses without the evidence set in
+`DOCTRINE.md` § The evidence rule.
+
+Final check is a **1× watch with no scrubbing, by someone who did not make it,**
+who is then asked exactly two questions: *what did she want,* and *what changed.*
+If they can't answer both, the problem is upstream of the edit and no amount of
+re-cutting fixes it.
+
+---
+
+## Failure modes and the stage that causes them
+
+| Symptom | Real cause | Stage to go back to |
+|---|---|---|
+| "It looks beautiful but I don't care" | No want established before world | 2 |
+| Characters sound the same | Word Ledgers missing or leaking | 2 |
+| "Feels like a trailer for a film" | No turn, or the turn is information not reversal | 1 |
+| Bin of clips, no film | Skipped 3 and 5 | 3 |
+| Faces drift | Re-described instead of character-ID reuse | 7 |
+| Reads as generic | Formal rule never declared, or broken silently | 5 |
+| Great picture, flat impact | Sound started after the cut | 5 |
+
+---
+
+Built on SIP.

--- a/packs/film-excellence/README.md
+++ b/packs/film-excellence/README.md
@@ -1,0 +1,64 @@
+# film-excellence
+
+A portable pack that makes narrative film and short-form work go through the
+same sequence in every repo — the film counterpart to `web-excellence`.
+
+It exists because the constraint in generative filmmaking has moved. Model
+access is table stakes; a jury sees the same photoreal clip from thousands of
+people. What is scarce is a believable character, designed sound, a formal rule
+the film obeys, dialogue that doesn't read as machine-written, and restraint.
+Every one of those is a writing and taste problem. This pack forces the budget
+there.
+
+## What's in it
+
+| File | What it is |
+|---|---|
+| [`DOCTRINE.md`](DOCTRINE.md) | The constitution — five laws, the refusal list, the evidence rule |
+| [`LANGUAGE.md`](LANGUAGE.md) | **The Spoken Law** — eleven AI-dialogue tells, ten rules that kill them, the Word Ledger technique, the generation protocol |
+| [`film-design.md`](film-design.md) | Token contract template — palette, lens, light, texture, sound map, cast locks |
+| [`film-taste.md`](film-taste.md) | Restraint test template — the four questions, language/structural/production refusals |
+| [`CREW.md`](CREW.md) | Seven chairs, two gates, model routing, and the bake-off protocol for verifying it |
+| [`PIPELINE.md`](PIPELINE.md) | Eight stages from premise to cut, with the failure-mode table |
+| [`skills/film-release-gate/`](skills/film-release-gate/SKILL.md) | The entry-point skill — sequences the pack, defines done, refuses without evidence |
+| [`templates/`](templates) | Story bible, character dossier, shot list schema |
+
+## Install
+
+```bash
+packs/film-excellence/install.sh /path/to/your/repo
+```
+
+Then one line in the repo's `CLAUDE.md`:
+
+> Film / narrative video work goes through the `film-release-gate` skill first.
+> See `.claude/skills/film-release-gate/SKILL.md`.
+
+## The contract shape
+
+Deliberately identical to the web contract already in use across the estate:
+
+- `film-design.md` carries **tokens** (what the film is made of)
+- `film-taste.md` carries **refusals** (what it will not be)
+- `film-release-gate` **sequences** the specialists and defines the finish line
+- A repo's own filled `film-design.md` / `film-taste.md` **outrank every skill**
+
+Nobody has to learn a new operating model — only a new medium.
+
+## Reference builds
+
+Two films built under this doctrine, sharing no palette, no lens language, no
+tempo, and no genre — which is the point. The doctrine is a set of forcing
+functions, not a style.
+
+- **`Holdfast`** — Arcanea, series-episode. Canon-bound.
+  → `frankxai/arcanea` `films/holdfast/`
+- **`What He Left Running`** — Starlight, freeform. Canon-free, substrate register.
+  → `frankxai/Starlight-Intelligence-System` `films/what-he-left-running/`
+
+Craft lives here so it can be reused; canon stays in the sovereign repo that
+owns it. Per SIP § Sovereignty, the substrate does not absorb vertical canon.
+
+---
+
+Built on SIP.

--- a/packs/film-excellence/film-design.md
+++ b/packs/film-excellence/film-design.md
@@ -68,10 +68,24 @@ sound:
     instrumentation: <string>
   # speech_free = nobody talking; room tone and foley continue. This is the
   # 20% budget. total_silence = no signal at all — a separate, rarer event.
+  # Store PER BEAT and derive every total. A summary figure with no per-item
+  # data behind it has nothing keeping it honest — see DOCTRINE.md § The
+  # derived-figure rule, which exists because both reference builds shipped
+  # this bug in six different forms before anyone caught it.
   speech_free:
-    at: <timecode>
-    duration: <seconds>
-    function: <string>
+    budget_seconds: <20% of runtime_picture>    # the floor
+    actual_seconds: <sum of beat_seconds>       # derive; never type by hand
+    beats: [<beat numbers>]
+    beat_seconds: { <beat>: <seconds>, … }      # the authoritative record
+    whole_beats: [<beats with no dialogue at all>]
+    partial_beats: [<beats that also carry dialogue>]
+    first_spoken_word_at: <timecode>
+    longest_span: <seconds>
+    longest_span_function: <string>
+  # total_silence is a SUBSET of speech-free, not a sibling: a signal-free
+  # moment obviously has no speech in it, so it already counts toward the
+  # budget above. Record it here to describe it, not to add it again.
+  # Set to null if the film never goes signal-free — most shouldn't.
   total_silence:                    # optional. If used, once only.
     at: <timecode>
     duration: <seconds>

--- a/packs/film-excellence/film-design.md
+++ b/packs/film-excellence/film-design.md
@@ -63,7 +63,13 @@ sound:
     in_point: <timecode>
     out_point: <timecode>
     instrumentation: <string>
-  silence:
+  # speech_free = nobody talking; room tone and foley continue. This is the
+  # 20% budget. total_silence = no signal at all — a separate, rarer event.
+  speech_free:
+    at: <timecode>
+    duration: <seconds>
+    function: <string>
+  total_silence:                    # optional. If used, once only.
     at: <timecode>
     duration: <seconds>
     function: <string>
@@ -91,8 +97,12 @@ empty, the rule was decorative. A real constraint costs you a shot you wanted.
 color, ban it from the entire film, then spend it once. Four seconds of a color
 the audience has not seen for three minutes lands harder than any effect.
 
-**`sound.silence`** — planned, timecoded, and given a *function*. Silence that
-happens because nothing was designed is not silence, it's absence.
+**`sound.speech_free` / `sound.total_silence`** — planned, timecoded, and given
+a *function*. Silence that happens because nothing was designed is not silence,
+it's absence. Keep the two apart: the first is a scene where nobody talks, the
+second is the track going to nothing, and confusing them produces either a
+dropout where you wanted restraint or a wall of tone where you wanted the floor
+to fall away.
 
 **`cast_locks.description`** — copied verbatim into every reference generation.
 Paraphrasing this string is the most common cause of face drift and it is

--- a/packs/film-excellence/film-design.md
+++ b/packs/film-excellence/film-design.md
@@ -13,7 +13,10 @@ defines "done." Nobody has to learn a new contract — only a new medium.
 ```yaml
 film:
   title: <string>
-  runtime_target: <mm:ss>          # HGFF: min 3:00, recommended ≤5:00 — verify on the live rules page
+  # Declare BOTH. A festival measures the delivered file, which includes the
+  # end card — so runtime_target is picture + card, never picture alone.
+  runtime_target: <mm:ss>          # total delivered runtime, card included
+  runtime_picture: <mm:ss>         # last beat out-point, card excluded
   aspect: <2.39:1 | 1.85:1 | 16:9 | 4:3 | 1:1>
   frame_rate: <24 | 25>            # 24 unless there is a reason
   track: <series-episode | synopsis | freeform>
@@ -89,6 +92,12 @@ cast_locks:                         # verbatim strings for character-reference g
 ---
 
 ## Notes on the fields that get skipped
+
+**`runtime_target` vs `runtime_picture`** — the beat sheet ends at the last
+beat's out-point, then a title card adds three or four seconds nobody counts.
+Declare both and let the difference be visible. A film whose stated runtime is
+its picture length is quietly wrong by the length of its own card, and the
+number that matters is the one a festival measures off the delivered file.
 
 **`formal_rule.where_it_hurt`** — if you finish production and this list is
 empty, the rule was decorative. A real constraint costs you a shot you wanted.

--- a/packs/film-excellence/film-design.md
+++ b/packs/film-excellence/film-design.md
@@ -1,0 +1,103 @@
+# film-design.md — the machine-readable film contract
+
+> The film equivalent of `design.md`. This is the **template**; each film copies
+> it and fills it. Tokens live here; judgment lives in `film-taste.md`.
+> A film's own filled copy outranks this template and outranks every skill.
+
+Same operating shape the web work already uses: `design.md` carries tokens,
+`taste.md` carries refusals, a release gate sequences the specialists and
+defines "done." Nobody has to learn a new contract — only a new medium.
+
+---
+
+```yaml
+film:
+  title: <string>
+  runtime_target: <mm:ss>          # HGFF: min 3:00, recommended ≤5:00 — verify on the live rules page
+  aspect: <2.39:1 | 1.85:1 | 16:9 | 4:3 | 1:1>
+  frame_rate: <24 | 25>            # 24 unless there is a reason
+  track: <series-episode | synopsis | freeform>
+
+formal_rule:                        # Doctrine Law 1 — exactly one, stated in one sentence
+  camera: <string>
+  color: <string>
+  sound: <string>
+  where_it_hurt: [<shot id>, <shot id>]   # filled during production; two minimum
+
+palette:
+  base: [<hex>, <hex>, <hex>]       # ≤3. The film lives here.
+  accent: <hex>
+  forbidden_color:                  # optional, extremely strong when used
+    hex: <hex>
+    total_screen_time: <seconds>
+    appears_at: [<timecode>]
+  grade_notes: <string>             # never teal/orange, never the purple-cyan default
+
+lens:
+  primary: <mm>                     # one focal length carries the film
+  secondary: <mm>
+  rules:
+    - <e.g. "no lens above 85mm before the turn">
+  depth_of_field: <string>
+
+light:
+  key_quality: <hard | soft | mixed>
+  sources_in_world: [<practical>, <practical>]   # name real sources; motivated light reads as real
+  direction_law: <string>
+
+texture:
+  grain: <string>
+  imperfections:                    # Doctrine Law 5 — three minimum
+    - shot: <id>
+      what: <string>
+  hands:                            # three deliberate hand shots
+    - shot: <id>
+      task: <string>
+
+sound:
+  bed:
+    - location: <string>
+      description: <string>
+  foley_priority: [<action>, <action>, <action>]
+  music:
+    in_point: <timecode>
+    out_point: <timecode>
+    instrumentation: <string>
+  silence:
+    at: <timecode>
+    duration: <seconds>
+    function: <string>
+
+typography:
+  title_card: <typeface, weight, tracking>
+  placement: <string>
+  rule: <e.g. "one card, at the end, four seconds, no music under it">
+
+cast_locks:                         # verbatim strings for character-reference generation
+  - name: <string>
+    character_id: <platform id, filled at stage 7>
+    description: <the exact string, never paraphrased>
+    asymmetry: <string>
+```
+
+---
+
+## Notes on the fields that get skipped
+
+**`formal_rule.where_it_hurt`** — if you finish production and this list is
+empty, the rule was decorative. A real constraint costs you a shot you wanted.
+
+**`forbidden_color`** — the strongest cheap move available. Pick a saturated
+color, ban it from the entire film, then spend it once. Four seconds of a color
+the audience has not seen for three minutes lands harder than any effect.
+
+**`sound.silence`** — planned, timecoded, and given a *function*. Silence that
+happens because nothing was designed is not silence, it's absence.
+
+**`cast_locks.description`** — copied verbatim into every reference generation.
+Paraphrasing this string is the most common cause of face drift and it is
+entirely self-inflicted.
+
+---
+
+Built on SIP.

--- a/packs/film-excellence/film-taste.md
+++ b/packs/film-excellence/film-taste.md
@@ -1,0 +1,93 @@
+# film-taste.md — the restraint test
+
+> The film equivalent of `taste.md`. The judgment the token spec cannot capture.
+> This is the **template**; each film copies it and adds its own refusals.
+> A film's filled copy outranks this template and every skill in the pack.
+
+`film-design.md` says what the film is made of. This says what it refuses to be.
+
+---
+
+## The one question
+
+Before any shot ships:
+
+> **If this shot appeared in someone else's film, would anyone be able to tell it wasn't ours?**
+
+If yes, it's a stock shot. It goes back. Not because it's bad — because it's
+nobody's.
+
+---
+
+## The restraint test
+
+Four questions, in order. Any "no" sends the work back.
+
+1. **Is there less?** The answer is usually yes. Fewer shots, fewer words, fewer
+   effects, less music, less camera movement. Generative tools make addition
+   free, which is exactly why subtraction is now the whole craft.
+2. **Does the rule hold?** The film's declared formal constraint — did this shot
+   break it? A broken rule is either a written exception or a shot that changes.
+3. **Whose is this?** Can you point at the decision in the frame that a model
+   would not have made on its own?
+4. **Would you watch it at 1× without scrubbing?** You already know. The urge to
+   scrub is the film telling you where it's dead.
+
+---
+
+## Language refusals
+
+Beyond the ten rules in `LANGUAGE.md`, no line of dialogue, title card, logline,
+synopsis, or festival description may contain:
+
+*unlock · harness · delve · journey (as metaphor) · elevate · seamless ·
+transform your · in a world where · little did they know · what if I told you ·
+the last of us/them · humanity's final · the age of · destiny awaits ·
+darkness rises · everything changed*
+
+This applies to the **submission copy** too. A film that obeys the doctrine and
+is submitted with a synopsis that says "in a world where magic has faded" has
+told the jury what to expect before they press play.
+
+---
+
+## Structural refusals
+
+- **No prologue.** If the film opens on text explaining the world, the film does
+  not trust itself. Start in a room with a person who wants something.
+- **No montage** without a formal justification written into the bible.
+- **No mentor scene** where an authority explains the rules to a newcomer, which
+  is to say, to the audience.
+- **No dream sequence.** It is the medium's oldest way of making something look
+  meaningful without meaning anything.
+- **No unmotivated slow motion.** Slow motion is a claim that this moment is
+  more important than the others. Make the claim once, or not at all.
+
+---
+
+## Production refusals
+
+- **No shot kept because it was expensive.** Sunk cost is the single most
+  reliable way for a generative production to end up bloated — retries are cheap
+  enough that the emotional attachment to a hard-won shot is the only thing
+  keeping it in.
+- **No face reused across characters.** Two characters who share a face read as
+  a mistake even when the audience can't say what's wrong.
+- **No score doing the work of a performance.** If the music is telling the
+  audience to feel something the face isn't earning, the problem is the shot.
+- **No self-assigned score.** "This is a 9/10 cut" is not evidence. See the
+  evidence rule in `DOCTRINE.md`.
+
+---
+
+## Local refusals
+
+> Each film appends its own here. These are the ones specific to *this* story —
+> the images that would be easy, correct, and wrong.
+
+- <film-specific refusal>
+- <film-specific refusal>
+
+---
+
+Built on SIP.

--- a/packs/film-excellence/install.sh
+++ b/packs/film-excellence/install.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# film-excellence — install into a target repo.
+# Idempotent: re-run to upgrade. --dry-run shows what would change.
+set -euo pipefail
+
+PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${1:-}"
+DRY_RUN=0
+
+for arg in "$@"; do
+  [ "$arg" = "--dry-run" ] && DRY_RUN=1
+done
+
+if [ -z "$TARGET" ] || [ "$TARGET" = "--dry-run" ]; then
+  echo "usage: install.sh /path/to/repo [--dry-run]" >&2
+  exit 2
+fi
+
+if [ ! -d "$TARGET" ]; then
+  echo "error: target '$TARGET' is not a directory" >&2
+  exit 1
+fi
+
+say() { echo "  $*"; }
+run() { if [ "$DRY_RUN" = "1" ]; then say "would: $*"; else "$@"; fi; }
+
+echo "film-excellence → $TARGET"
+
+# 1. The release-gate skill.
+run mkdir -p "$TARGET/.claude/skills/film-release-gate"
+run cp "$PACK_DIR/skills/film-release-gate/SKILL.md" \
+       "$TARGET/.claude/skills/film-release-gate/SKILL.md"
+say "installed skill: film-release-gate"
+
+# 2. Doctrine + reference docs, alongside the skill so they load together.
+run mkdir -p "$TARGET/.claude/skills/film-release-gate/reference"
+for f in DOCTRINE.md LANGUAGE.md CREW.md PIPELINE.md; do
+  run cp "$PACK_DIR/$f" "$TARGET/.claude/skills/film-release-gate/reference/$f"
+  say "installed reference: $f"
+done
+
+# 3. Templates — copied only if absent. Never overwrite a filled contract.
+for f in film-design.md film-taste.md; do
+  if [ -e "$TARGET/$f" ]; then
+    say "kept existing $f (a filled contract outranks the template)"
+  else
+    run cp "$PACK_DIR/$f" "$TARGET/$f"
+    say "installed template: $f"
+  fi
+done
+
+run mkdir -p "$TARGET/.claude/templates/film"
+run cp -r "$PACK_DIR/templates/." "$TARGET/.claude/templates/film/"
+say "installed templates: story-bible, character-dossier, shotlist.schema"
+
+cat <<'EOF'
+
+Done. Add one line to the repo's CLAUDE.md:
+
+  Film / narrative video work goes through the `film-release-gate` skill first.
+  See `.claude/skills/film-release-gate/SKILL.md`. This repo's own
+  `film-design.md` and `film-taste.md` outrank every skill in the pack.
+
+EOF

--- a/packs/film-excellence/skills/film-release-gate/SKILL.md
+++ b/packs/film-excellence/skills/film-release-gate/SKILL.md
@@ -58,7 +58,10 @@ Certification requires **all** of the following as artifacts, not assertions:
 - [ ] **Three hand shots**, timecoded
 - [ ] **Three deliberate imperfections**, timecoded
 - [ ] **Language pass** logged — the eleven-item checklist from `LANGUAGE.md`
-- [ ] **Silence ≥ 20%** of runtime, measured not estimated
+- [ ] **Speech-free ≥ 20%** of runtime, measured not estimated. *Speech-free*
+      means nobody is talking; room tone and foley continue. Do not accept a
+      signal-free track as evidence — that is a dropout. A deliberate **total
+      silence** is a separate, timecoded entry in the sound map
 - [ ] **Generation ledger** complete — every shot reconstructible from seed
 - [ ] **Cold watch**: one person who did not make it watched at 1× with no
       scrubbing and can answer *what did she want* and *what changed*

--- a/packs/film-excellence/skills/film-release-gate/SKILL.md
+++ b/packs/film-excellence/skills/film-release-gate/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: film-release-gate
+description: Sequences film and short-form narrative work and defines the finish line. Use FIRST for any film, short, series episode, trailer, or narrative video work — before writing a script, designing a shot, or generating a single frame. Also use when asked to review, certify, or ship a cut. Refuses to certify without evidence.
+---
+
+# film-release-gate
+
+The entry point for narrative film work. It does two jobs: it **sequences** the
+other artifacts in the `film-excellence` pack, and it **defines done**.
+
+It is the film equivalent of `web-release-gate`, and it works the same way:
+you don't get to self-certify.
+
+---
+
+## Read order (do not skip)
+
+1. The repo's own `film-design.md` and `film-taste.md` if they exist — **they
+   outrank everything below.**
+2. `DOCTRINE.md` — the five laws and the refusal list
+3. `LANGUAGE.md` — before any dialogue is written
+4. `film-design.md` (pack template) — the token contract
+5. `CREW.md` — which chair, which model
+6. `PIPELINE.md` — the eight stages
+
+---
+
+## Sequence
+
+Refuse to jump stages. The most common and most expensive error in generative
+film production is starting at stage 7.
+
+```
+1 BIBLE      → turn stated in one line, formal rule declared
+2 CHARACTERS → Word Ledger + locked visual string per principal
+3 BEATS      → timecoded, turn located between 2:30 and 3:10
+4 SCRIPT     → LANGUAGE.md checklist passes
+5 LOOK+SOUND → sound map written BEFORE any frame is generated
+6 SHOTLIST   → rule_check = yes on every row
+7 GENERATE   → character IDs reused, every generation logged
+8 CUT        → assembled to the sound map, then this gate
+```
+
+If a user asks to "just generate some shots" before stage 5 exists, say what is
+missing and what it will cost — a bin of unusable clips and a face that drifts —
+then offer the shortest real path: bible and beats first, one hour.
+
+---
+
+## The gate
+
+Certification requires **all** of the following as artifacts, not assertions:
+
+- [ ] **The turn**, in one line, in the form *they think X; actually Y*
+- [ ] **The formal rule**, declared, plus the two places it hurt (shot ids)
+- [ ] **Sound map**: bed per location · foley on three actions · music in/out ·
+      the planned silence with its function and duration
+- [ ] **Three hand shots**, timecoded
+- [ ] **Three deliberate imperfections**, timecoded
+- [ ] **Language pass** logged — the eleven-item checklist from `LANGUAGE.md`
+- [ ] **Silence ≥ 20%** of runtime, measured not estimated
+- [ ] **Generation ledger** complete — every shot reconstructible from seed
+- [ ] **Cold watch**: one person who did not make it watched at 1× with no
+      scrubbing and can answer *what did she want* and *what changed*
+- [ ] **Runtime** inside the target window
+- [ ] **Submission copy** passes the language refusals in `film-taste.md`
+
+Missing any item → **not certified.** Report which, and the shortest path to
+each. Do not soften this and do not average the criteria into a score.
+
+**Never assign a numeric quality score to your own work.** The gate is
+pass/fail on evidence. A score is a way of feeling finished without being
+finished.
+
+---
+
+## Adversarial pass
+
+Before certifying, run one deliberate hostile read. The prompt to yourself is
+not "is this good" — it is:
+
+> **"A jury has watched four hundred of these this week. Give me the three
+> sentences they will use to dismiss this one."**
+
+If those three sentences are true, the film is not ready. If you cannot produce
+three, you are not looking hard enough — produce them anyway, then check.
+
+---
+
+## Anti-patterns this gate exists to catch
+
+| Pattern | What it actually is |
+|---|---|
+| "The visuals are stunning" | No turn |
+| "It's more of a mood piece" | No want |
+| "The music really carries it" | The performances don't |
+| "We'll fix it in the edit" | Stage 3 was skipped |
+| "Every shot took forty retries" | Character IDs weren't used |
+| "I'd give this a 9" | Self-certification |
+
+---
+
+Built on SIP.

--- a/packs/film-excellence/templates/character-dossier.md
+++ b/packs/film-excellence/templates/character-dossier.md
@@ -1,0 +1,51 @@
+# <NAME> — <role>
+
+## Want
+<What they want from the *situation*, in human terms — not the plot objective.
+"To be believed," not "to escape." The film is about the human want and never
+says it aloud.>
+
+## Wound
+<One or two sentences. What happened. Never dramatised on screen.>
+
+## What they will not say
+<The word or admission they route around for the whole film. The audience feels
+the shape of the hole.>
+
+## Physical asymmetry
+<A scar, a crooked tooth, a badly healed break, a curled finger. Written here so
+it persists across every generated shot. Note where in the film it is hidden and
+where it stops being hidden.>
+
+## Word Ledger
+**Only they say:** <5 words — from their trade, region, or damage. No other
+character may use these.>
+**They cannot say:** <5 words — usually the emotional register they avoid.>
+**Grammatical tic:** <A *structure*, never a phonetic accent. Answers questions
+with questions · never contracts · starts sentences twice · passive when lying.>
+
+## Locked visual string
+> <The exact phrasing used for character-reference generation. Copied verbatim
+> into every reference call — never paraphrased. Age, build, hair, wardrobe, the
+> asymmetry, and one detail that never changes. Paraphrasing this string is the
+> most common cause of face drift.>
+
+`character_id:` <filled at pipeline stage 7>
+
+## Arc
+<Not "weak → strong." State the actual transaction: unseen → seen, certain →
+uncertain, owed → released.>
+
+## Function
+<What this character does *for the audience*. Often: they are the audience's
+proxy, and their face at the turn is where the emotion lands.>
+
+---
+
+## Ledger conflict check
+<Run across all principals. No lexical overlap. Note the one deliberate
+collision, if the script has one — the same word meaning different things in two
+mouths is the strongest line available.>
+
+---
+Built on SIP.

--- a/packs/film-excellence/templates/shotlist.schema.md
+++ b/packs/film-excellence/templates/shotlist.schema.md
@@ -1,0 +1,59 @@
+# Shot list schema
+
+One row per shot. Budget **1.4× the shots you think you need** — coverage is
+what lets you cut around a shot that never comes out right, and in generative
+production some shots never do.
+
+## Columns
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `S001` | Stable. Never renumber; the ledger references it. |
+| `beat` | int | Which beat from `TREATMENT.md` |
+| `duration` | seconds | Sums to the runtime target. Check this early. |
+| `size` | `ECU\|CU\|MCU\|MS\|WS\|EWS` | |
+| `height` | `ground\|knee\|table\|chest\|eye\|above` | The column that enforces most camera laws |
+| `movement` | `locked\|pan\|tilt\|dolly\|handheld\|rack` | `locked` should dominate. If it doesn't, ask why. |
+| `subject` | text | |
+| `light` | text | Name the in-world source. Unmotivated light reads as rendered. |
+| `prompt_seed` | text | The generation prompt, minus character description |
+| `character_ids` | list | **Reused IDs, never re-descriptions.** |
+| `sound_cue` | text | From the sound map in `film-design.md` |
+| `rule_check` | `yes\|no` | Hard check against the declared formal rule |
+| `status` | `pending\|generating\|kept\|retry\|flagged` | |
+| `takes` | int | Retry count. Cap 3, then flag to the Showrunner. |
+
+## Rules
+
+- **`rule_check = no` is not allowed to ship.** Either the shot changes or the
+  bible records a written exception. Three exceptions and the rule wasn't real.
+- **`character_ids` is never empty on a shot with a person in it.** A shot that
+  re-describes a character in `prompt_seed` is a face-drift bug waiting to
+  happen, and it is entirely self-inflicted.
+- **`takes > 3` escalates.** Do not grind. A shot that will not come out is
+  usually a shot that is wrong, and the fix is upstream in the shot list.
+- **`movement = handheld` requires a written justification.** If the camera has
+  a body, the film is claiming something. Claim it once.
+
+## CSV header
+
+```csv
+id,beat,duration,size,height,movement,subject,light,prompt_seed,character_ids,sound_cue,rule_check,status,takes
+```
+
+## Generation ledger
+
+Separate file, `LEDGER.jsonl`, one line per generation attempt — not per shot:
+
+```json
+{"shot":"S014","attempt":2,"model":"<model>","prompt":"<full>","seed":"<seed>",
+ "character_ids":["<id>"],"cost":0.00,"verdict":"retry","reason":"eyeline wrong",
+ "ts":"<iso8601>"}
+```
+
+Non-negotiable for three reasons: retry needs the seed, a festival may require a
+production breakdown, and a film you cannot reconstruct is a film you cannot
+defend.
+
+---
+Built on SIP.

--- a/packs/film-excellence/templates/story-bible.md
+++ b/packs/film-excellence/templates/story-bible.md
@@ -1,0 +1,49 @@
+# <TITLE> — story bible
+
+> <universe> · <track> · target runtime <mm:ss> · aspect <ratio> · <fps>
+> Canon: <path or "none"> · Craft: `film-excellence` pack
+> Status: **draft — not locked.**
+
+## Logline
+<One sentence. The situation and the pressure. Not the theme.>
+
+## The turn
+> **They think X; actually Y.**
+
+<Two or three sentences on what the reversal recontextualises. If it only adds
+information, it is not a turn.>
+
+Turn lands at **<timecode>** — between 2:30 and 3:10 for a 4:00 film.
+
+## The last shot
+<Describe it. Write it before the middle exists.>
+
+## What this is *not* about
+<Three or four refusals. This field prevents forty shots of a world that has no
+business in a four-minute film.>
+
+## Formal rule
+**Camera:** <one sentence>
+**Color:** <one sentence, incl. forbidden color if any>
+**Sound:** <one sentence>
+
+## Why this premise and not another
+<What the obvious version of this film is, why everyone will make it, and what
+this one inverts. If you cannot answer this, the premise is the obvious one.>
+
+## Canon binding
+| Element | Canon source | Use in film |
+|---|---|---|
+| | | |
+
+**Canon flags:** <contradictions found in the canon, raised not fixed>
+**Canon questions:** <extensions needing a keeper ruling before script lock>
+
+## Series promise *(series-episode track only)*
+<What episode one asks and does not answer.>
+
+## Track fit
+<Why this film fits the track it is entered in.>
+
+---
+Built on SIP.


### PR DESCRIPTION
## What this is

The film counterpart to `web-excellence`, built for the Higgsfield Global Film Festival campaign (opens 7 Aug, closes 31 Aug) but designed to outlive it.

It deliberately reuses the contract shape the estate already runs on the web side, so nobody has to learn a new operating model for a new medium:

- **`film-design.md`** carries tokens — palette, lens, light, texture, sound map, cast locks
- **`film-taste.md`** carries refusals — what the film will not be
- **`film-release-gate`** sequences the eight stages and defines done
- A repo's own filled contracts **outrank every skill in the pack**

## The premise

Model access stopped being a differentiator. A jury sees the same photoreal clip from thousands of people. What is still scarce, in order: a believable character, designed sound, a formal rule the film obeys, dialogue that doesn't read as machine-written, and restraint. Every one of those is a writing and taste problem, not a generation problem. The pack forces the budget there.

## Contents

| File | What it does |
|---|---|
| `DOCTRINE.md` | Five laws, the refusal list (openers/grammar/palettes/sound/faces/structures we don't shoot), the evidence rule |
| `LANGUAGE.md` | **The Spoken Law** — eleven tells that identify AI dialogue, ten binary rules that kill them, the Word Ledger technique, and a generation protocol that never asks a model for a scene |
| `film-design.md` | Token contract template |
| `film-taste.md` | Restraint test template |
| `CREW.md` | Seven chairs, two gates, model routing — plus a blind bake-off protocol for *verifying* that routing rather than assuming it |
| `PIPELINE.md` | Eight stages, parallelism rules (writing serial, generation pipelined, sound parallel from the beat sheet), failure-mode table |
| `skills/film-release-gate/SKILL.md` | Entry-point skill. Refuses to certify without evidence; never assigns itself a score |
| `templates/` | Story bible, character dossier, shot list schema + ledger format |
| `install.sh` | Idempotent. Never overwrites a filled `film-design.md`/`film-taste.md` |

## Verification

`install.sh` tested end-to-end into a clean directory: installs the skill, its four reference docs, both contract templates, and the three templates. Re-running preserves filled contracts rather than clobbering them.

## Reference builds

Two films under this doctrine, sharing no palette, lens language, tempo, or genre — the doctrine is a set of forcing functions, not a style.

- **HOLDFAST** (Arcanea, series-episode) → `frankxai/arcanea` `films/holdfast/`
- **WHAT HE LEFT RUNNING** (Starlight, freeform) → `frankxai/Starlight-Intelligence-System` `films/what-he-left-running/`

Craft lives here so it is reusable; canon stays in the repo that owns it, per SIP § Sovereignty.

## Notes for review

- No hook layer yet. `web-excellence` gets its enforcement from three committed hooks; this pack currently relies on the skill description and a `CLAUDE.md` line. Hooks are the obvious follow-up if film work becomes recurring rather than campaign-shaped.
- No `SOURCES.md` — unlike `web-excellence`, nothing here is vendored. It is all native, so there is no provenance to pin.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpSgW8xWCDcBYmsSAXopfB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the new **film-excellence** production pack for structured AI-assisted filmmaking.
  * Introduced an eight-stage workflow covering story development, scripting, visual design, generation, editing, and release.
  * Added film design, taste, character, story-bible, and shot-list templates.
  * Added dialogue, sound, visual consistency, and narrative-quality standards.
  * Added an installer with dry-run support and safe upgrades.
  * Added an evidence-based release gate for final-film certification.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->