### PR TITLE
Repair license ownership and upstream provenance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Claude Skills Library
+Copyright (c) 2025–2026 Frank Riemer and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,5 @@
+# Third-party and contributor notices
+
+The root MIT license applies to original contributions by Frank Riemer and contributors. Individual skills, examples, references, or bundled assets derived from another project remain governed by their original copyright and license notices.
+
+Do not remove nested LICENSE or attribution files. Adding a skill to this catalog does not transfer its copyright to Frank Riemer or the Claude Skills Library.


### PR DESCRIPTION
Records the exact ownership and upstream boundary for Claude Skills Library, preserves existing third-party licenses, and avoids claiming rights in imported material. Part of frankxai/arcanea#114.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added third-party licensing and attribution guidance.
  * Clarified how original contributions, derived materials, and bundled assets are covered.

* **Chores**
  * Updated the MIT License copyright attribution for 2025–2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->